### PR TITLE
Add performance settings panel with persistent options

### DIFF
--- a/core/signals.py
+++ b/core/signals.py
@@ -19,7 +19,11 @@ def als_baseline(y: np.ndarray, lam: float = 1e5, p: float = 0.001,
     y = np.asarray(y, dtype=float)
     L = y.size
     # second-order difference matrix
-    D = np.diff(np.eye(L), 2)
+    # ``np.diff`` defaults to operating along the last axis, which would yield
+    # a (L, L-2) matrix and subsequently cause shape mismatches when forming
+    # ``D.T @ D``. Explicitly differencing along rows produces the intended
+    # (L-2, L) matrix so that ``D.T @ D`` is square (L x L).
+    D = np.diff(np.eye(L), 2, axis=0)
     w = np.ones(L)
     z = np.zeros_like(y)
     for _ in range(int(niter)):


### PR DESCRIPTION
## Summary
- Add Performance settings panel with checkboxes for Numba, GPU/CuPy, baseline caching, and deterministic seeding
- Wire checkboxes to `infra.performance` helpers and persist selections using `infra.config`
- Initialize performance options on startup from stored configuration
- Fix ALS baseline computation by constructing the difference matrix along rows to prevent shape mismatches

## Testing
- `python -m py_compile ui/app.py`
- `python -m py_compile core/signals.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa550db1708330bcce919c1b91352d