### PR TITLE
Fix ALS baseline matrix dimension mismatch

### DIFF
--- a/core/signals.py
+++ b/core/signals.py
@@ -18,8 +18,8 @@ def als_baseline(y: np.ndarray, lam: float = 1e5, p: float = 0.001,
 
     y = np.asarray(y, dtype=float)
     L = y.size
-    # second-order difference matrix
-    D = np.diff(np.eye(L), 2)
+    # second-order difference matrix; diff along rows to keep square result
+    D = np.diff(np.eye(L), 2, axis=0)
     w = np.ones(L)
     z = np.zeros_like(y)
     for _ in range(int(niter)):


### PR DESCRIPTION
## Summary
- fix ALS baseline difference matrix so W and D.T@D shapes align

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa645762f0833094067a298c2fa067