### PR TITLE
Fix LMfit parameter bounds

### DIFF
--- a/fit/bounds.py
+++ b/fit/bounds.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from typing import Sequence, Tuple
+
+import numpy as np
+
+from core.peaks import Peak
+
+
+def pack_theta_bounds(
+    peaks: Sequence[Peak], x: np.ndarray, options: dict
+) -> Tuple[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
+    """Return initial parameter vector and bounds honoring locks and limits."""
+
+    x = np.asarray(x, dtype=float)
+    x_min = float(x.min()) if x.size else -np.inf
+    x_max = float(x.max()) if x.size else np.inf
+    min_fwhm = float(options.get("min_fwhm", 1e-6))
+    clamp_center = bool(options.get("centers_in_window", False))
+
+    theta0 = []
+    lb = []
+    ub = []
+
+    eps = 1e-12
+    for p in peaks:
+        # center
+        c = float(p.center)
+        lb_c = x_min if clamp_center else -np.inf
+        ub_c = x_max if clamp_center else np.inf
+        if p.lock_center:
+            lb_c = c - eps
+            ub_c = c + eps
+        theta0.append(np.clip(c, lb_c, ub_c))
+        lb.append(lb_c)
+        ub.append(ub_c)
+
+        # height
+        h = max(float(p.height), 0.0)
+        theta0.append(h)
+        lb.append(0.0)
+        ub.append(np.inf)
+
+        # width
+        w = max(float(p.fwhm), min_fwhm)
+        lb_w = min_fwhm
+        ub_w = np.inf
+        if p.lock_width:
+            lb_w = w - eps
+            ub_w = w + eps
+        theta0.append(np.clip(w, lb_w, ub_w))
+        lb.append(lb_w)
+        ub.append(ub_w)
+
+        # eta
+        e = float(np.clip(p.eta, 0.0, 1.0))
+        theta0.append(e)
+        lb.append(0.0)
+        ub.append(1.0)
+
+    theta0_arr = np.asarray(theta0, dtype=float)
+    lb_arr = np.asarray(lb, dtype=float)
+    ub_arr = np.asarray(ub, dtype=float)
+    return theta0_arr, (lb_arr, ub_arr)

--- a/fit/lmfit_backend.py
+++ b/fit/lmfit_backend.py
@@ -57,24 +57,85 @@ def solve(
     y = np.asarray(y, dtype=float)
     baseline = np.asarray(baseline, dtype=float) if baseline is not None else None
 
+    # Build consistent bounds/initial values with other solvers
+    from .bounds import pack_theta_bounds
+
+    theta0, (lb, ub) = pack_theta_bounds(peaks, x, options)
+
     params = lmfit.Parameters()
     share_w = bool(options.get("share_fwhm", False))
     share_e = bool(options.get("share_eta", False))
-    if share_w:
-        params.add("w0", value=peaks[0].fwhm, min=0)
-    if share_e:
-        params.add("e0", value=peaks[0].eta, min=0, max=1)
+
+    # Add shared parameters first if requested
+    if share_w and peaks:
+        params.add(
+            "w0",
+            value=theta0[2],
+            min=lb[2],
+            max=ub[2],
+            vary=lb[2] != ub[2],
+        )
+    if share_e and peaks:
+        params.add(
+            "e0",
+            value=theta0[3],
+            min=lb[3],
+            max=ub[3],
+            vary=lb[3] != ub[3],
+        )
+
+    idx = 0
     for i, p in enumerate(peaks):
-        params.add(f"c{i}", value=p.center, vary=not p.lock_center)
-        params.add(f"h{i}", value=p.height)
-        if share_w and i > 0:
-            params.add(f"w{i}", expr="w0")
+        c0, h0, w0_i, e0_i = theta0[idx : idx + 4]
+        lb_c, ub_c = lb[idx], ub[idx]
+        lb_h, ub_h = lb[idx + 1], ub[idx + 1]
+        lb_w, ub_w = lb[idx + 2], ub[idx + 2]
+        lb_e, ub_e = lb[idx + 3], ub[idx + 3]
+
+        params.add(
+            f"c{i}",
+            value=c0,
+            min=lb_c,
+            max=ub_c,
+            vary=lb_c != ub_c,
+        )
+        params.add(
+            f"h{i}",
+            value=h0,
+            min=lb_h,
+            max=ub_h,
+        )
+
+        if share_w:
+            if i == 0:
+                # already have w0 parameter defined
+                pass
+            else:
+                params.add(f"w{i}", expr="w0")
         else:
-            params.add(f"w{i}", value=p.fwhm, min=0, vary=not p.lock_width)
-        if share_e and i > 0:
-            params.add(f"e{i}", expr="e0")
+            params.add(
+                f"w{i}",
+                value=w0_i,
+                min=lb_w,
+                max=ub_w,
+                vary=lb_w != ub_w,
+            )
+
+        if share_e:
+            if i == 0:
+                pass
+            else:
+                params.add(f"e{i}", expr="e0")
         else:
-            params.add(f"e{i}", value=p.eta, min=0, max=1)
+            params.add(
+                f"e{i}",
+                value=e0_i,
+                min=lb_e,
+                max=ub_e,
+                vary=lb_e != ub_e,
+            )
+
+        idx += 4
 
     def residual(pars: lmfit.Parameters) -> np.ndarray:
         pk: list[Peak] = []

--- a/fit/modern.py
+++ b/fit/modern.py
@@ -9,6 +9,7 @@ from scipy.optimize import least_squares
 
 from core.peaks import Peak
 from core.residuals import build_residual
+from .bounds import pack_theta_bounds
 
 
 class SolveResult(TypedDict):
@@ -61,20 +62,7 @@ def solve(
     elif weight_mode == "inv_y":
         weights = 1.0 / np.clip(y, 1e-12, None)
 
-    theta0 = _theta_from_peaks(peaks)
-    n_params = theta0.size
-
-    # bounds: enforce positive heights/FWHM and 0<=eta<=1; centers free
-    lb = np.full(n_params, -np.inf)
-    ub = np.full(n_params, np.inf)
-    for i in range(len(peaks)):
-        lb[4 * i + 1] = 0.0  # height >=0
-        lb[4 * i + 2] = options.get("min_fwhm", 1e-6)
-        lb[4 * i + 3] = 0.0
-        ub[4 * i + 3] = 1.0
-        if options.get("centers_in_window", False):
-            lb[4 * i] = x.min()
-            ub[4 * i] = x.max()
+    theta0, (lb, ub) = pack_theta_bounds(peaks, x, options)
 
     best = None
     best_cost = np.inf
@@ -84,6 +72,8 @@ def solve(
         if jitter_pct:
             jitter = 1.0 + jitter_pct / 100.0 * rng.standard_normal(theta0.shape)
             start = theta0 * jitter
+            # jitter might push parameters outside the bounds
+            start = np.minimum(np.maximum(start, lb), ub)
         else:
             start = theta0
 
@@ -107,7 +97,7 @@ def solve(
         raise RuntimeError("least_squares did not run")
 
     ok = bool(best.success)
-    theta = best.x
+    theta = np.minimum(np.maximum(best.x, lb), ub)
     jac = best.jac if ok else None
     cov = None
     if jac is not None:

--- a/fit/step_engine.py
+++ b/fit/step_engine.py
@@ -46,6 +46,14 @@ def step_once(
     )
 
     theta0 = _theta_from_peaks(peaks)
+    lb = ub = None
+    if bounds is not None:
+        lb, ub = bounds
+        lb = np.asarray(lb, dtype=float)
+        ub = np.asarray(ub, dtype=float)
+        # ensure starting vector honours the bounds
+        theta0 = np.minimum(np.maximum(theta0, lb), ub)
+
     resid_fn = build_residual(x, y, peaks, mode, baseline, loss, weights)
     r0 = resid_fn(theta0)
 
@@ -85,9 +93,6 @@ def step_once(
 
     theta1 = theta0 + delta
     if bounds is not None:
-        lb, ub = bounds
-        lb = np.asarray(lb, dtype=float)
-        ub = np.asarray(ub, dtype=float)
         theta1 = np.minimum(np.maximum(theta1, lb), ub)
 
     r1 = resid_fn(theta1)

--- a/tests/test_classic.py
+++ b/tests/test_classic.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from fit import classic
+from core.peaks import Peak
+
+
+def test_classic_clips_parameters():
+    x = np.linspace(0, 10, 50)
+    y = np.zeros_like(x)
+    peaks = [Peak(-5.0, -1.0, -2.0, 1.5)]
+    res = classic.solve(
+        x,
+        y,
+        peaks,
+        mode="add",
+        baseline=None,
+        options={"centers_in_window": True, "min_fwhm": 1.0},
+    )
+    theta = res["theta"]
+    assert res["ok"]
+    assert np.allclose(theta, [0.0, 0.0, 1.0, 1.0])

--- a/tests/test_lmfit_bounds.py
+++ b/tests/test_lmfit_bounds.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from core.peaks import Peak
+from fit import lmfit_backend
+
+
+def test_lmfit_respects_locks_and_bounds():
+    lmfit = pytest.importorskip("lmfit")
+    x = np.linspace(0, 10, 50)
+    y = np.zeros_like(x)
+    peaks = [Peak(5.0, -1.0, -0.5, 1.2, lock_center=True, lock_width=True)]
+    res = lmfit_backend.solve(
+        x,
+        y,
+        peaks,
+        mode="add",
+        baseline=None,
+        options={"centers_in_window": True, "min_fwhm": 1.0},
+    )
+    theta = res["theta"]
+    assert np.allclose(theta, [5.0, 0.0, 1.0, 1.0])

--- a/tests/test_modern_step_bounds.py
+++ b/tests/test_modern_step_bounds.py
@@ -1,0 +1,48 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from core.peaks import Peak
+from fit import modern, step_engine
+from fit.bounds import pack_theta_bounds
+
+
+def test_modern_respects_locks_and_bounds():
+    x = np.linspace(0, 10, 50)
+    y = np.zeros_like(x)
+    peaks = [Peak(5.0, -1.0, -0.5, 1.2, lock_center=True, lock_width=True)]
+    res = modern.solve(
+        x,
+        y,
+        peaks,
+        mode="add",
+        baseline=None,
+        options={"centers_in_window": True, "min_fwhm": 1.0},
+    )
+    theta = res["theta"]
+    assert np.allclose(theta, [5.0, 0.0, 1.0, 1.0])
+
+
+def test_step_engine_respects_bounds():
+    x = np.linspace(0, 10, 50)
+    y = np.zeros_like(x)
+    peaks = [Peak(5.0, -1.0, -0.5, 1.2, lock_center=True, lock_width=True)]
+    _, bounds = pack_theta_bounds(peaks, x, {"centers_in_window": True, "min_fwhm": 1.0})
+    theta, _ = step_engine.step_once(
+        x,
+        y,
+        peaks,
+        "add",
+        None,
+        loss="linear",
+        weights=None,
+        damping=0.0,
+        trust_radius=np.inf,
+        bounds=bounds,
+    )
+    assert np.allclose(theta, [5.0, 0.0, 1.0, 1.0])

--- a/ui/app.py
+++ b/ui/app.py
@@ -48,6 +48,7 @@ from scipy.signal import find_peaks
 from core import signals
 from core.residuals import build_residual
 from fit import classic, lmfit_backend, modern, step_engine
+from fit.bounds import pack_theta_bounds
 from infra import performance
 from batch import runner as batch_runner
 from uncertainty import asymptotic, bayes, bootstrap
@@ -1100,11 +1101,21 @@ class PeakFitApp:
         base_fit = self.baseline[mask] if (base_applied and add_mode) else None
         mode = "add" if add_mode else "subtract"
 
+        options = self._solver_options()
+        _, bounds = pack_theta_bounds(self.peaks, x_fit, options)
+
         try:
             theta, _ = step_engine.step_once(
-                x_fit, y_fit, self.peaks, mode, base_fit,
-                loss="linear", weights=None, damping=0.0,
-                trust_radius=np.inf, bounds=None
+                x_fit,
+                y_fit,
+                self.peaks,
+                mode,
+                base_fit,
+                loss="linear",
+                weights=None,
+                damping=0.0,
+                trust_radius=np.inf,
+                bounds=bounds,
             )
         except Exception as e:
             messagebox.showerror("Step", f"Step failed:\n{e}")


### PR DESCRIPTION
## Summary
- enforce min/max bounds and locked parameters in LMfit solver using shared `pack_theta_bounds`
- add regression test verifying LMfit honours width and center locks

## Testing
- `pip install numpy lmfit -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa81d178bc83308f1c54a55b198485