### PR TITLE
Add debug log window and progress tracking

### DIFF
--- a/batch/runner.py
+++ b/batch/runner.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import glob
 from pathlib import Path
-from typing import Iterable, Sequence, List
+from typing import Iterable, Sequence, List, Callable, Optional
 
 import numpy as np
 
@@ -51,7 +51,7 @@ def _auto_seed(x: np.ndarray, y: np.ndarray, baseline: np.ndarray, max_peaks: in
     return found
 
 
-def run(patterns: Iterable[str], config: dict) -> None:
+def run(patterns: Iterable[str], config: dict, progress: Optional[Callable[[str], None]] = None) -> None:
     """Run the peak fitting pipeline over matching files.
 
     Parameters
@@ -89,6 +89,8 @@ def run(patterns: Iterable[str], config: dict) -> None:
     records = []
 
     for path in files:
+        if progress:
+            progress(f"Processing {path}")
         x, y = data_io.load_xy(path)
         baseline = signals.als_baseline(
             y,
@@ -157,6 +159,8 @@ def run(patterns: Iterable[str], config: dict) -> None:
             trace_path = Path(path).with_suffix(Path(path).suffix + ".trace.csv")
             with trace_path.open("w", encoding="utf-8") as fh:
                 fh.write(trace_csv)
+        if progress:
+            progress(f"Finished {path}")
 
     peak_csv = data_io.build_peak_table(records)
     with open(peak_output, "w", encoding="utf-8") as fh:


### PR DESCRIPTION
## Summary
- add a simple debug log window and “Show Log” button
- report progress while loading files, computing baselines, fitting, batch runs, uncertainty, and exports
- allow batch runner to emit per-file progress via callback

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aaa2d6e3ac8330b5e8e948fec303e5