### PR TITLE
Fix baseline handling in classic solver

### DIFF
--- a/batch/runner.py
+++ b/batch/runner.py
@@ -114,7 +114,9 @@ def run(patterns: Iterable[str], config: dict, progress: Optional[Callable[[str]
                     tpl.height = float(max(sig[idx_near], 1e-6))
 
         opts = config.get(solver_name, {})
-        res = _apply_solver(solver_name, x, y, template, mode, baseline, opts)
+        y_fit = y - baseline if mode == "subtract" else y
+        base_arg = baseline if mode == "add" else None
+        res = _apply_solver(solver_name, x, y_fit, template, mode, base_arg, opts)
 
         theta = np.asarray(res["theta"], dtype=float)
         fitted = []
@@ -124,7 +126,7 @@ def run(patterns: Iterable[str], config: dict, progress: Optional[Callable[[str]
 
         model = models.pv_sum(x, fitted)
         resid = model + (baseline if mode == "add" else 0.0) - (
-            y if mode == "add" else y - baseline
+            y if mode == "add" else y_fit
         )
         rmse = float(np.sqrt(np.mean(resid**2)))
         areas = [models.pv_area(p.height, p.fwhm, p.eta) for p in fitted]

--- a/tests/test_classic_subtract.py
+++ b/tests/test_classic_subtract.py
@@ -1,0 +1,25 @@
+import sys
+from pathlib import Path
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from fit import classic
+from core.peaks import Peak
+from core.models import pv_sum
+
+def test_classic_subtract_ignores_baseline():
+    x = np.linspace(0, 10, 100)
+    baseline = 0.1 * x
+    peak_true = Peak(5.0, 2.0, 1.0, 0.5)
+    y = pv_sum(x, [peak_true]) + baseline
+    y_sub = y - baseline
+    guess = [Peak(5.0, 1.0, 1.0, 0.5)]
+
+    res_none = classic.solve(x, y_sub, guess, mode="subtract", baseline=None, options={})
+    res_with = classic.solve(x, y_sub, guess, mode="subtract", baseline=baseline, options={})
+
+    assert np.allclose(res_none["theta"], [5.0, 2.0, 1.0, 0.5])
+    assert np.allclose(res_with["theta"], res_none["theta"])


### PR DESCRIPTION
## Summary
- ensure classic solver ignores baseline in subtract mode and includes baseline in cost
- pre-subtract baseline before batch-mode subtract fits
- test subtract-mode baseline handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aaa451e24c8330989e455fc3e2d418