### PR TITLE
Apply peak bound options to classic solver

### DIFF
--- a/ui/app.py
+++ b/ui/app.py
@@ -527,21 +527,32 @@ class PeakFitApp:
 
     def _solver_options(self) -> dict:
         solver = self.solver_var.get().lower()
-        if solver == "modern":
-            min_fwhm = 1e-6
-            if self.modern_min_fwhm.get() and self.x is not None and self.x.size > 1:
+
+        # Options that apply to both solvers
+        min_fwhm = 1e-6
+        if self.x is not None and self.x.size > 1:
+            if self.modern_min_fwhm.get():
                 min_fwhm = 2.0 * float(np.median(np.diff(self.x)))
-            return {
-                "loss": self.modern_loss.get(),
-                "weights": self.modern_weight.get(),
-                "f_scale": float(self.modern_fscale.get()),
-                "maxfev": int(self.modern_maxfev.get()),
-                "restarts": int(self.modern_restarts.get()),
-                "jitter_pct": float(self.modern_jitter.get()),
-                "centers_in_window": bool(self.modern_centers_window.get()),
-                "min_fwhm": float(min_fwhm),
-            }
-        return {"maxfev": int(self.classic_maxfev.get())}
+        opts = {
+            "centers_in_window": bool(self.modern_centers_window.get()),
+            "min_fwhm": float(min_fwhm),
+        }
+
+        if solver == "modern":
+            opts.update(
+                {
+                    "loss": self.modern_loss.get(),
+                    "weights": self.modern_weight.get(),
+                    "f_scale": float(self.modern_fscale.get()),
+                    "maxfev": int(self.modern_maxfev.get()),
+                    "restarts": int(self.modern_restarts.get()),
+                    "jitter_pct": float(self.modern_jitter.get()),
+                }
+            )
+        else:
+            opts["maxfev"] = int(self.classic_maxfev.get())
+
+        return opts
 
     def _new_figure(self):
         self.ax.clear()


### PR DESCRIPTION
## Summary
- Ensure solver options always include `centers_in_window` and `min_fwhm`
- Share bound-related options between classic and modern solvers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aaaec90b64833091d602fe7047bfed