### PR TITLE
Use least squares for classic solver

### DIFF
--- a/fit/classic.py
+++ b/fit/classic.py
@@ -1,12 +1,21 @@
-"""Classic solver backend using SciPy's least squares routines."""
+"""Classic solver backend using SciPy's least squares routines.
+
+This implementation mirrors the behaviour of Peakfit 2.7 where the solver
+optimises peak heights as well as any unlocked centers and widths.  It relies
+on :func:`scipy.optimize.least_squares` with simple linear loss and without the
+robust weighting/restart features provided by the modern solver.
+"""
+
 from __future__ import annotations
 
-from typing import Optional, Sequence, TypedDict
+from typing import Optional, TypedDict
 
 import numpy as np
+from scipy.optimize import least_squares
 
-from core.models import pv_sum
 from core.peaks import Peak
+from core.residuals import build_residual
+from .bounds import pack_theta_bounds
 
 
 class SolveResult(TypedDict):
@@ -21,13 +30,6 @@ class SolveResult(TypedDict):
     meta: dict
 
 
-def _theta_from_peaks(peaks: Sequence[Peak]) -> np.ndarray:
-    arr = []
-    for p in peaks:
-        arr.extend([p.center, p.height, p.fwhm, p.eta])
-    return np.asarray(arr, dtype=float)
-
-
 def solve(
     x: np.ndarray,
     y: np.ndarray,
@@ -36,62 +38,61 @@ def solve(
     baseline: np.ndarray | None,
     options: dict,
 ) -> SolveResult:
-    """Fit peak heights with centers/widths fixed using linear least squares.
+    """Solve the non-linear least squares problem for classic fitting.
 
-    This lightweight implementation serves as an initial backend so the UI can
-    demonstrate fitting. It solves for peak heights only and returns an array of
-    full peak parameters to remain compatible with the blueprint API.
+    Parameters
+    ----------
+    x, y : ndarray
+        Data points.
+    peaks : list[Peak]
+        Initial peak guesses with lock flags.
+    mode : str
+        Baseline mode (``"add"`` or ``"subtract"``).
+    baseline : ndarray | None
+        Baseline array if applicable.
+    options : dict
+        Solver options supporting ``centers_in_window``, ``min_fwhm`` and
+        ``maxfev``.
     """
 
     x = np.asarray(x, dtype=float)
     y = np.asarray(y, dtype=float)
     base_arr = np.asarray(baseline, dtype=float) if baseline is not None else None
-    target = y - (base_arr if base_arr is not None else 0.0)
 
-    # enforce basic bounds on provided peak parameters
-    x_min = float(x.min())
-    x_max = float(x.max())
-    min_fwhm = float(options.get("min_fwhm", 1e-6))
-    clamp_center = bool(options.get("centers_in_window", False))
-    clean: list[Peak] = []
-    for p in peaks:
-        c = p.center
-        if clamp_center:
-            c = float(np.clip(c, x_min, x_max))
-        h = max(p.height, 0.0)
-        w = max(p.fwhm, min_fwhm)
-        e = float(np.clip(p.eta, 0.0, 1.0))
-        clean.append(Peak(c, h, w, e))
-
-    A_cols = []
-    for p in clean:
-        unit = Peak(p.center, 1.0, p.fwhm, p.eta)
-        A_cols.append(pv_sum(x, [unit]))
-    A = np.column_stack(A_cols) if A_cols else np.zeros((x.size, 0))
-    try:
-        heights, *_ = np.linalg.lstsq(A, target, rcond=None)
-        heights = np.maximum(heights, 0.0)
-        ok = True
-        message = "linear least squares"
-    except np.linalg.LinAlgError as exc:  # pragma: no cover - ill-conditioned
-        heights = np.zeros(len(clean))
-        ok = False
-        message = str(exc)
-
-    updated = [Peak(p.center, h, p.fwhm, p.eta) for p, h in zip(clean, heights)]
-    theta = _theta_from_peaks(updated)
-    model = pv_sum(x, updated)
+    # Handle baseline according to mode
+    y_target = y
+    base_model = None
     if base_arr is not None:
-        model = model + base_arr
-    resid = y - model
-    cost = float(0.5 * np.dot(resid, resid))
+        if mode == "subtract":
+            y_target = y - base_arr
+        else:  # add
+            base_model = base_arr
+
+    maxfev = int(options.get("maxfev", 20000))
+
+    theta0, (lb, ub) = pack_theta_bounds(peaks, x, options)
+    resid_fn = build_residual(x, y_target, peaks, base_model, "linear", None)
+
+    res = least_squares(resid_fn, theta0, max_nfev=maxfev, bounds=(lb, ub))
+
+    theta = np.minimum(np.maximum(res.x, lb), ub)
+    cost = 0.5 * float(res.cost)
+    jac = res.jac if res.success else None
+    cov = None
+    if jac is not None:
+        try:
+            JTJ_inv = np.linalg.pinv(jac.T @ jac)
+            cov = JTJ_inv
+        except np.linalg.LinAlgError:  # pragma: no cover - singular
+            cov = None
 
     return SolveResult(
-        ok=ok,
+        ok=bool(res.success),
         theta=theta,
-        message=message,
+        message=res.message,
         cost=cost,
-        jac=None,
-        cov=None,
-        meta={},
+        jac=jac,
+        cov=cov,
+        meta={"nfev": res.nfev, "njev": getattr(res, "njev", None)},
     )
+

--- a/fit/modern.py
+++ b/fit/modern.py
@@ -2,7 +2,7 @@
 with support for robust losses, weights and multi-start restarts."""
 from __future__ import annotations
 
-from typing import Optional, Sequence, TypedDict
+from typing import Optional, TypedDict
 
 import numpy as np
 from scipy.optimize import least_squares
@@ -22,13 +22,6 @@ class SolveResult(TypedDict):
     meta: dict
 
 
-def _theta_from_peaks(peaks: Sequence[Peak]) -> np.ndarray:
-    arr: list[float] = []
-    for p in peaks:
-        arr.extend([p.center, p.height, p.fwhm, p.eta])
-    return np.asarray(arr, dtype=float)
-
-
 def solve(
     x: np.ndarray,
     y: np.ndarray,
@@ -46,7 +39,16 @@ def solve(
 
     x = np.asarray(x, dtype=float)
     y = np.asarray(y, dtype=float)
-    baseline = np.asarray(baseline, dtype=float) if baseline is not None else None
+    base_arr = np.asarray(baseline, dtype=float) if baseline is not None else None
+
+    # Handle baseline according to mode
+    y_target = y
+    base_model = None
+    if base_arr is not None:
+        if mode == "subtract":
+            y_target = y - base_arr
+        else:  # add
+            base_model = base_arr
 
     loss = options.get("loss", "linear")
     weight_mode = options.get("weights", "none")
@@ -58,9 +60,9 @@ def solve(
     # construct weights
     weights = None
     if weight_mode == "poisson":
-        weights = 1.0 / np.sqrt(np.clip(y, 1.0, None))
+        weights = 1.0 / np.sqrt(np.clip(y_target, 1.0, None))
     elif weight_mode == "inv_y":
-        weights = 1.0 / np.clip(y, 1e-12, None)
+        weights = 1.0 / np.clip(y_target, 1e-12, None)
 
     theta0, (lb, ub) = pack_theta_bounds(peaks, x, options)
 
@@ -77,7 +79,7 @@ def solve(
         else:
             start = theta0
 
-        resid_fn = build_residual(x, y, peaks, baseline, loss, weights)
+        resid_fn = build_residual(x, y_target, peaks, base_model, loss, weights)
 
         res = least_squares(
             resid_fn,

--- a/tests/test_modern_subtract.py
+++ b/tests/test_modern_subtract.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from fit import modern
+from core.peaks import Peak
+from core.models import pv_sum
+
+
+def test_modern_subtract_uses_baseline():
+    x = np.linspace(0, 10, 100)
+    baseline = 0.1 * x
+    peak_true = Peak(5.0, 2.0, 1.0, 0.5)
+    y = pv_sum(x, [peak_true]) + baseline
+    guess = [Peak(5.0, 1.0, 1.0, 0.5)]
+
+    res = modern.solve(x, y, guess, mode="subtract", baseline=baseline, options={})
+
+    assert np.allclose(res["theta"], [5.0, 2.0, 1.0, 0.5])

--- a/ui/app.py
+++ b/ui/app.py
@@ -527,21 +527,32 @@ class PeakFitApp:
 
     def _solver_options(self) -> dict:
         solver = self.solver_var.get().lower()
-        if solver == "modern":
-            min_fwhm = 1e-6
-            if self.modern_min_fwhm.get() and self.x is not None and self.x.size > 1:
+
+        # Options that apply to both solvers
+        min_fwhm = 1e-6
+        if self.x is not None and self.x.size > 1:
+            if self.modern_min_fwhm.get():
                 min_fwhm = 2.0 * float(np.median(np.diff(self.x)))
-            return {
-                "loss": self.modern_loss.get(),
-                "weights": self.modern_weight.get(),
-                "f_scale": float(self.modern_fscale.get()),
-                "maxfev": int(self.modern_maxfev.get()),
-                "restarts": int(self.modern_restarts.get()),
-                "jitter_pct": float(self.modern_jitter.get()),
-                "centers_in_window": bool(self.modern_centers_window.get()),
-                "min_fwhm": float(min_fwhm),
-            }
-        return {"maxfev": int(self.classic_maxfev.get())}
+        opts = {
+            "centers_in_window": bool(self.modern_centers_window.get()),
+            "min_fwhm": float(min_fwhm),
+        }
+
+        if solver == "modern":
+            opts.update(
+                {
+                    "loss": self.modern_loss.get(),
+                    "weights": self.modern_weight.get(),
+                    "f_scale": float(self.modern_fscale.get()),
+                    "maxfev": int(self.modern_maxfev.get()),
+                    "restarts": int(self.modern_restarts.get()),
+                    "jitter_pct": float(self.modern_jitter.get()),
+                }
+            )
+        else:
+            opts["maxfev"] = int(self.classic_maxfev.get())
+
+        return opts
 
     def _new_figure(self):
         self.ax.clear()


### PR DESCRIPTION
## Summary
- Rewrite classic solver to perform full least-squares optimization of peak parameters
- Handle baseline add/subtract modes and honor bounds via `pack_theta_bounds`
- Pass bounds options to both solvers and align modern solver with baseline handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aaaec90b64833091d602fe7047bfed