### PR TITLE
Accelerate solvers with analytic pseudo-Voigt Jacobian

### DIFF
--- a/fit/classic.py
+++ b/fit/classic.py
@@ -1,18 +1,18 @@
-"""Classic solver backend using SciPy's least squares routines."""
+"""Classic solver backend using SciPy's least-squares with analytic Jacobian."""
+
 from __future__ import annotations
 
 from typing import Optional, Sequence, TypedDict
 
 import numpy as np
-from scipy.optimize import lsq_linear
+from scipy.optimize import least_squares
 
-from core.models import pv_sum
-from core.peaks import Peak
+from core.residuals import build_residual_jac
+from core.models import pv_design_matrix
+from .bounds import pack_theta_bounds
 
 
 class SolveResult(TypedDict):
-    """Return structure for solver results."""
-
     ok: bool
     theta: np.ndarray
     message: str
@@ -22,89 +22,140 @@ class SolveResult(TypedDict):
     meta: dict
 
 
-def _theta_from_peaks(peaks: Sequence[Peak]) -> np.ndarray:
-    arr = []
-    for p in peaks:
-        arr.extend([p.center, p.height, p.fwhm, p.eta])
-    return np.asarray(arr, dtype=float)
+def _to_solver_vectors(theta0: np.ndarray, bounds, peaks, fwhm_min: float):
+    lb, ub = bounds
+    theta_list = []
+    lb_list = []
+    ub_list = []
+    x_scale = []
+    indices = []
+    for i, p in enumerate(peaks):
+        h = theta0[4 * i + 1]
+        theta_list.append(h)
+        lb_list.append(lb[4 * i + 1])
+        ub_list.append(ub[4 * i + 1])
+        x_scale.append(max(1.0, abs(h)))
+        indices.append(4 * i + 1)
+        if not p.lock_center:
+            c = theta0[4 * i + 0]
+            theta_list.append(c)
+            lb_list.append(lb[4 * i + 0])
+            ub_list.append(ub[4 * i + 0])
+            x_scale.append(max(theta0[4 * i + 2], fwhm_min))
+            indices.append(4 * i + 0)
+        if not p.lock_width:
+            w = theta0[4 * i + 2]
+            theta_list.append(w)
+            lb_list.append(lb[4 * i + 2])
+            ub_list.append(ub[4 * i + 2])
+            x_scale.append(max(w, fwhm_min))
+            indices.append(4 * i + 2)
+    return (
+        np.asarray(theta_list, dtype=float),
+        (np.asarray(lb_list, dtype=float), np.asarray(ub_list, dtype=float)),
+        np.asarray(x_scale, dtype=float),
+        np.asarray(indices, dtype=int),
+    )
 
 
 def solve(
     x: np.ndarray,
     y: np.ndarray,
-    peaks: list,
+    peaks: Sequence,
     mode: str,
     baseline: np.ndarray | None,
     options: dict,
 ) -> SolveResult:
-    """Fit peak heights with centers/widths fixed using linear least squares.
-
-    This lightweight implementation serves as an initial backend so the UI can
-    demonstrate fitting. It solves for peak heights only and returns an array of
-    full peak parameters to remain compatible with the blueprint API.
-    """
-
     x = np.asarray(x, dtype=float)
     y = np.asarray(y, dtype=float)
-    baseline = np.asarray(baseline, dtype=float) if baseline is not None else 0.0
+    baseline = np.asarray(baseline, dtype=float) if baseline is not None else None
 
-    if mode == "add":
-        target = y - baseline
-    elif mode == "subtract":
-        target = y - baseline
-    else:  # pragma: no cover - unknown mode
+    weight_mode = options.get("weights", "none")
+    weights = None
+    if weight_mode == "poisson":
+        weights = 1.0 / np.sqrt(np.clip(np.abs(y), 1.0, None))
+    elif weight_mode == "inv_y":
+        weights = 1.0 / np.clip(np.abs(y), 1e-12, None)
+
+    theta0_full, bounds_full = pack_theta_bounds(peaks, x, options)
+    dx_med = float(np.median(np.diff(x))) if x.size > 1 else 1.0
+    fwhm_min = max(float(options.get("min_fwhm", 1e-6)), 2.0 * dx_med)
+
+    all_locked = all(p.lock_center and p.lock_width for p in peaks)
+
+    base = baseline if baseline is not None else 0.0
+    y_target = y - base
+
+    if all_locked:
+        A = pv_design_matrix(x, peaks)
+        if weights is not None:
+            Aw = A * weights[:, None]
+            yw = y_target * weights
+        else:
+            Aw = A
+            yw = y_target
+        h, *_ = np.linalg.lstsq(Aw, yw, rcond=None)
+        model = A @ h
+        r = model - y_target
+        if weights is not None:
+            r = r * weights
+        cost = 0.5 * float(r @ r)
+        theta_full = theta0_full.copy()
+        for i, val in enumerate(h):
+            theta_full[4 * i + 1] = val
+        jac = Aw if weights is not None else A
         return SolveResult(
-            ok=False,
-            theta=_theta_from_peaks(peaks),
-            message="unknown mode",
-            cost=float("nan"),
-            jac=None,
+            ok=True,
+            theta=theta_full,
+            message="linear",
+            cost=cost,
+            jac=jac,
             cov=None,
-            meta={},
+            meta={"nfev": 1},
         )
 
-    # enforce basic bounds on provided peak parameters
-    x_min = float(x.min())
-    x_max = float(x.max())
-    min_fwhm = float(options.get("min_fwhm", 1e-6))
-    clamp_center = bool(options.get("centers_in_window", False))
-    clean: list[Peak] = []
-    for p in peaks:
-        c = p.center
-        if clamp_center:
-            c = float(np.clip(c, x_min, x_max))
-        h = max(p.height, 0.0)
-        w = max(p.fwhm, min_fwhm)
-        e = float(np.clip(p.eta, 0.0, 1.0))
-        clean.append(Peak(c, h, w, e))
+    theta0, bounds, x_scale, indices = _to_solver_vectors(theta0_full, bounds_full, peaks, fwhm_min)
+    resid_jac = build_residual_jac(x, y, peaks, mode, baseline, weights)
 
-    A_cols = []
-    for p in clean:
-        unit = Peak(p.center, 1.0, p.fwhm, p.eta)
-        A_cols.append(pv_sum(x, [unit]))
-    A = np.column_stack(A_cols) if A_cols else np.zeros((x.size, 0))
-    try:
-        res = lsq_linear(A, target, bounds=(0.0, np.inf))
-        heights = res.x
-        ok = res.success
-        message = res.message
-    except Exception as exc:  # pragma: no cover - solver failure
-        heights = np.zeros(len(peaks))
-        ok = False
-        message = str(exc)
+    def fun(t):
+        r, _ = resid_jac(t)
+        return r
 
-    updated = [Peak(p.center, h, p.fwhm, p.eta) for p, h in zip(clean, heights)]
-    theta = _theta_from_peaks(updated)
-    model = pv_sum(x, updated)
-    resid = target - model
-    cost = float(0.5 * np.dot(resid, resid))
+    def jac(t):
+        _, J = resid_jac(t)
+        return J
+
+    maxfev = int(options.get("maxfev", 20000))
+
+    res = least_squares(
+        fun,
+        theta0,
+        jac=jac,
+        method="trf",
+        loss="linear",
+        bounds=bounds,
+        x_scale=x_scale,
+        max_nfev=maxfev,
+    )
+
+    ok = bool(res.success)
+    theta_full = theta0_full.copy()
+    theta_full[indices] = res.x
+    jac_full = res.jac
+    cov = None
+    if jac_full is not None:
+        try:
+            cov = np.linalg.pinv(jac_full.T @ jac_full)
+        except np.linalg.LinAlgError:
+            cov = None
 
     return SolveResult(
         ok=ok,
-        theta=theta,
-        message=message,
-        cost=cost,
-        jac=None,
-        cov=None,
-        meta={},
+        theta=theta_full,
+        message=res.message,
+        cost=float(res.cost),
+        jac=jac_full,
+        cov=cov,
+        meta={"nfev": res.nfev, "njev": getattr(res, "njev", None)},
     )
+

--- a/fit/modern.py
+++ b/fit/modern.py
@@ -1,13 +1,14 @@
-"""Modern solver backend employing Trust Region Reflective algorithm
-with support for robust losses, weights and multi-start restarts."""
+"""Modern solver with robust losses and analytic Jacobian."""
+
 from __future__ import annotations
 
-from typing import Optional, TypedDict
+from typing import Optional, Sequence, TypedDict
 
 import numpy as np
 from scipy.optimize import least_squares
 
-from core.residuals import build_residual
+from core.residuals import build_residual_jac
+from core.models import pv_design_matrix
 from .bounds import pack_theta_bounds
 
 
@@ -21,21 +22,50 @@ class SolveResult(TypedDict):
     meta: dict
 
 
+def _to_solver_vectors(theta0: np.ndarray, bounds, peaks, fwhm_min: float):
+    lb, ub = bounds
+    theta_list = []
+    lb_list = []
+    ub_list = []
+    x_scale = []
+    indices = []
+    for i, p in enumerate(peaks):
+        h = theta0[4 * i + 1]
+        theta_list.append(h)
+        lb_list.append(lb[4 * i + 1])
+        ub_list.append(ub[4 * i + 1])
+        x_scale.append(max(1.0, abs(h)))
+        indices.append(4 * i + 1)
+        if not p.lock_center:
+            c = theta0[4 * i + 0]
+            theta_list.append(c)
+            lb_list.append(lb[4 * i + 0])
+            ub_list.append(ub[4 * i + 0])
+            x_scale.append(max(theta0[4 * i + 2], fwhm_min))
+            indices.append(4 * i + 0)
+        if not p.lock_width:
+            w = theta0[4 * i + 2]
+            theta_list.append(w)
+            lb_list.append(lb[4 * i + 2])
+            ub_list.append(ub[4 * i + 2])
+            x_scale.append(max(w, fwhm_min))
+            indices.append(4 * i + 2)
+    return (
+        np.asarray(theta_list, dtype=float),
+        (np.asarray(lb_list, dtype=float), np.asarray(ub_list, dtype=float)),
+        np.asarray(x_scale, dtype=float),
+        np.asarray(indices, dtype=int),
+    )
+
+
 def solve(
     x: np.ndarray,
     y: np.ndarray,
-    peaks: list,
+    peaks: Sequence,
     mode: str,
     baseline: np.ndarray | None,
     options: dict,
 ) -> SolveResult:
-    """Solve the non-linear least squares problem using SciPy's TRF solver.
-
-    Parameters in ``options`` follow the blueprint: ``loss`` (passed directly to
-    :func:`scipy.optimize.least_squares`), ``weights`` (``none`` | ``poisson`` |
-    ``inv_y``), ``f_scale``, ``maxfev``, ``restarts`` and ``jitter_pct``.
-    """
-
     x = np.asarray(x, dtype=float)
     y = np.asarray(y, dtype=float)
     baseline = np.asarray(baseline, dtype=float) if baseline is not None else None
@@ -47,14 +77,49 @@ def solve(
     restarts = int(options.get("restarts", 1))
     jitter_pct = float(options.get("jitter_pct", 0.0))
 
-    # construct weights
     weights = None
     if weight_mode == "poisson":
-        weights = 1.0 / np.sqrt(np.clip(y, 1.0, None))
+        weights = 1.0 / np.sqrt(np.clip(np.abs(y), 1.0, None))
     elif weight_mode == "inv_y":
-        weights = 1.0 / np.clip(y, 1e-12, None)
+        weights = 1.0 / np.clip(np.abs(y), 1e-12, None)
 
-    theta0, (lb, ub) = pack_theta_bounds(peaks, x, options)
+    theta0_full, bounds_full = pack_theta_bounds(peaks, x, options)
+    dx_med = float(np.median(np.diff(x))) if x.size > 1 else 1.0
+    fwhm_min = max(float(options.get("min_fwhm", 1e-6)), 2.0 * dx_med)
+
+    all_locked = all(p.lock_center and p.lock_width for p in peaks)
+    base = baseline if baseline is not None else 0.0
+    y_target = y - base
+
+    if all_locked:
+        A = pv_design_matrix(x, peaks)
+        if weights is not None:
+            Aw = A * weights[:, None]
+            yw = y_target * weights
+        else:
+            Aw = A
+            yw = y_target
+        h, *_ = np.linalg.lstsq(Aw, yw, rcond=None)
+        model = A @ h
+        r = model - y_target
+        if weights is not None:
+            r = r * weights
+        cost = 0.5 * float(r @ r)
+        theta_full = theta0_full.copy()
+        for i, val in enumerate(h):
+            theta_full[4 * i + 1] = val
+        jac = Aw if weights is not None else A
+        return SolveResult(
+            ok=True,
+            theta=theta_full,
+            message="linear",
+            cost=cost,
+            jac=jac,
+            cov=None,
+            meta={"nfev": 1},
+        )
+
+    theta0, bounds, x_scale, indices = _to_solver_vectors(theta0_full, bounds_full, peaks, fwhm_min)
 
     best = None
     best_cost = np.inf
@@ -64,46 +129,58 @@ def solve(
         if jitter_pct:
             jitter = 1.0 + jitter_pct / 100.0 * rng.standard_normal(theta0.shape)
             start = theta0 * jitter
+            lb, ub = bounds
             start = np.minimum(np.maximum(start, lb), ub)
         else:
             start = theta0
 
-        resid_fn = build_residual(x, y, peaks, mode, baseline, loss, weights)
+        resid_jac = build_residual_jac(x, y, peaks, mode, baseline, weights)
+
+        def fun(t):
+            r, _ = resid_jac(t)
+            return r
+
+        def jac(t):
+            _, J = resid_jac(t)
+            return J
 
         res = least_squares(
-            resid_fn,
+            fun,
             start,
+            jac=jac,
+            method="trf",
             loss=loss,
             f_scale=f_scale,
+            bounds=bounds,
+            x_scale=x_scale,
             max_nfev=maxfev,
-            bounds=(lb, ub),
         )
 
-        cost = 0.5 * float(res.cost)
+        cost = float(res.cost)
         if cost < best_cost:
             best = res
             best_cost = cost
 
     if best is None:  # pragma: no cover - should not happen
-        raise RuntimeError("least_squares did not run")
+        raise RuntimeError("least_squares failed")
 
-    ok = bool(best.success)
-    theta = best.x
-    jac = best.jac if ok else None
+    theta_full = theta0_full.copy()
+    theta_full[indices] = best.x
+    jac_full = best.jac
     cov = None
-    if jac is not None:
+    if jac_full is not None:
         try:
-            JTJ_inv = np.linalg.pinv(jac.T @ jac)
-            cov = JTJ_inv
-        except np.linalg.LinAlgError:  # pragma: no cover - singular
+            cov = np.linalg.pinv(jac_full.T @ jac_full)
+        except np.linalg.LinAlgError:
             cov = None
 
     return SolveResult(
-        ok=ok,
-        theta=theta,
+        ok=bool(best.success),
+        theta=theta_full,
         message=best.message,
         cost=best_cost,
-        jac=jac,
+        jac=jac_full,
         cov=cov,
         meta={"nfev": best.nfev, "njev": getattr(best, "njev", None)},
     )
+


### PR DESCRIPTION
## Summary
- Implement analytic pseudo-Voigt model with Jacobian and linear design matrix
- Build weighted residual/Jacobian pipeline with tighter FWHM bounds
- Rewrite Classic, Modern and LMFIT solvers to use analytic derivatives, parameter scaling and linear height-only fast path

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aad7e5f8c483309df35967c06d93f0