### PR TITLE
feat: add solver iteration interface

### DIFF
--- a/fit/modern_vp.py
+++ b/fit/modern_vp.py
@@ -10,6 +10,7 @@ from core.models import pv_design_matrix, pv_sum_with_jac
 from core.peaks import Peak
 from .bounds import pack_theta_bounds
 from .utils import mad_sigma, robust_cost
+from . import step_engine
 
 
 class SolveResult(TypedDict):
@@ -329,3 +330,48 @@ def solve(
         cov=cov,
         meta={"nfev": nfev, "sigma": sigma, "f_scale": fs, "backtracked": backtracked},
     )
+
+
+def iterate(state: dict) -> dict:
+    """Single iteration for the variable projection solver.
+
+    This helper mirrors the behaviour of :func:`solve` but performs only a
+    single Gauss–Newton/LM step by delegating to :func:`step_engine.step_once`.
+    It accepts and returns a ``state`` dictionary similar to the other solver
+    backends.
+    """
+
+    x = state["x_fit"]
+    y = state["y_fit"]
+    peaks = state["peaks"]
+    mode = state.get("mode", "subtract")
+    baseline = state.get("baseline")
+    options = state.get("options", {})
+
+    loss = options.get("loss", "linear")
+    weight_mode = options.get("weights", "none")
+    weights = None
+    if weight_mode == "poisson":
+        weights = 1.0 / np.sqrt(np.clip(np.abs(y), 1.0, None))
+    elif weight_mode == "inv_y":
+        weights = 1.0 / np.clip(np.abs(y), 1e-12, None)
+
+    _, bounds = pack_theta_bounds(peaks, x, options)
+
+    theta, cost = step_engine.step_once(
+        x,
+        y,
+        peaks,
+        mode,
+        baseline,
+        loss=loss,
+        weights=weights,
+        damping=state.get("lambda", 0.0),
+        trust_radius=state.get("trust_radius", np.inf),
+        bounds=bounds,
+        f_scale=options.get("f_scale", 1.0),
+    )
+
+    state["theta"] = theta
+    state["cost"] = cost
+    return state


### PR DESCRIPTION
## Summary
- add `iterate` helper to classic, modern, modern_vp and lmfit solvers
- wire GUI Step button to solver-specific `iterate` function

## Testing
- `python -m py_compile fit/classic.py fit/modern.py fit/modern_vp.py fit/lmfit_backend.py ui/app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab5bf4e0b8833083e8e4772d90743e