### PR TITLE
Expose multiple fitting backends

### DIFF
--- a/batch/runner.py
+++ b/batch/runner.py
@@ -15,15 +15,19 @@ from typing import Iterable, Sequence, List
 import numpy as np
 
 from core import data_io, models, peaks, signals
-from fit import classic, lmfit_backend, modern
+from fit import classic, lmfit_backend, modern, modern_vp
 
 
 def _apply_solver(name: str, x, y, pk, mode, baseline, options):
     if name == "classic":
         return classic.solve(x, y, pk, mode, baseline, options)
-    if name == "modern":
+    if name == "modern_vp":
+        return modern_vp.solve(x, y, pk, mode, baseline, options)
+    if name == "modern_trf":
         return modern.solve(x, y, pk, mode, baseline, options)
-    return lmfit_backend.solve(x, y, pk, mode, baseline, options)
+    if name == "lmfit_vp":
+        return lmfit_backend.solve(x, y, pk, mode, baseline, options)
+    raise ValueError("unknown solver")
 
 
 def _auto_seed(x: np.ndarray, y: np.ndarray, baseline: np.ndarray, max_peaks: int = 5) -> List[peaks.Peak]:
@@ -60,8 +64,8 @@ def run(patterns: Iterable[str], config: dict) -> None:
         Iterable of glob patterns. All matching files are processed.
     config:
         Dictionary describing the batch job. Supported keys include ``peaks``
-        (list of peak dictionaries), ``solver`` (``classic`` | ``modern`` |
-        ``lmfit``), ``mode`` (``add`` | ``subtract``), ``baseline``
+        (list of peak dictionaries), ``solver`` (``classic`` | ``modern_vp`` |
+        ``modern_trf`` | ``lmfit_vp``), ``mode`` (``add`` | ``subtract``), ``baseline``
         parameters, per-solver options, ``save_traces`` flag, ``peak_output``
         for the output CSV, ``source`` (``current`` | ``template`` | ``auto``)
         selecting the peak seeds, ``reheight`` to refresh heights per spectrum

--- a/uncertainty/bootstrap.py
+++ b/uncertainty/bootstrap.py
@@ -30,7 +30,8 @@ def bootstrap(base_solver: str, resample_cfg: dict, residual_builder) -> UncRepo
     Parameters
     ----------
     base_solver:
-        Which solver backend to use (``"classic"``, ``"modern"``, ``"lmfit"``).
+        Which solver backend to use (``"classic"``, ``"modern_vp"``,
+        ``"modern_trf"``, ``"lmfit_vp"``).
     resample_cfg:
         Dictionary describing the problem. Expected keys are ``x``, ``y``,
         ``peaks`` (template peaks), ``mode``, ``baseline``, ``theta`` (final
@@ -43,9 +44,11 @@ def bootstrap(base_solver: str, resample_cfg: dict, residual_builder) -> UncRepo
 
     if base_solver == "classic":
         from fit.classic import solve as solver
-    elif base_solver == "modern":
+    elif base_solver == "modern_vp":
+        from fit.modern_vp import solve as solver
+    elif base_solver == "modern_trf":
         from fit.modern import solve as solver
-    elif base_solver == "lmfit":
+    elif base_solver == "lmfit_vp":
         from fit.lmfit_backend import solve as solver
     else:  # pragma: no cover - unknown solver
         raise ValueError("unknown solver")


### PR DESCRIPTION
## Summary
- Persist solver choice in config and migrate legacy values
- Add radiobutton "Fitting method" selector with Classic, Modern VP, Modern TRF and optional LMFIT VP backends
- Allow bootstrap uncertainty to choose base solver and update batch/uncertainty modules for new solver names

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab6634ce308330b326da4ca79b57bb