### PR TITLE
fix(step): centralize noise/robust weights and use them in Step ▶ + backends; resolve NameError

### DIFF
--- a/core/robust.py
+++ b/core/robust.py
@@ -1,55 +1,8 @@
-import numpy as np
+"""Backward compatibility wrappers for weight helpers."""
 
+from .weights import noise_weights, robust_weights
 
-def irls_weights(resid, loss, f_scale, eps=1e-12):
-    """Return IRLS weights for residuals under ``loss``.
+# ``irls_weights`` was the previous public name for ``robust_weights``
+irls_weights = robust_weights
 
-    Parameters
-    ----------
-    resid : array_like
-        Residual vector.
-    loss : {"linear", "soft_l1", "huber", "cauchy"}
-        Robust loss name.
-    f_scale : float
-        Scale parameter for the robust loss.
-    eps : float, optional
-        Small positive value guarding against division by zero.
-    """
-    r = np.asarray(resid, dtype=float)
-    fs = float(max(f_scale, eps))
-    z = r / fs
-    if loss == "linear":
-        w = np.ones_like(z)
-    elif loss == "soft_l1":
-        w = (1.0 + z ** 2) ** -0.25
-    elif loss == "huber":
-        w = np.ones_like(z)
-        mask = np.abs(z) > 1.0
-        w[mask] = np.sqrt(1.0 / np.abs(z[mask]))
-    elif loss == "cauchy":
-        w = (1.0 + z ** 2) ** -0.5
-    else:  # pragma: no cover - unknown loss
-        raise ValueError(f"unknown loss '{loss}'")
-    return w
-
-
-def noise_weights(y, mode, floor=1e-12):
-    """Return per-point noise weights according to ``mode``.
-
-    Parameters
-    ----------
-    y : array_like
-        Observed data.
-    mode : {"none", "poisson", "inv_y"}
-        Weighting strategy.
-    floor : float, optional
-        Minimum absolute value used when ``mode`` is ``inv_y``.
-    """
-    arr = np.asarray(y, dtype=float)
-    if mode == "none":
-        return np.ones_like(arr)
-    if mode == "poisson":
-        return 1.0 / np.sqrt(np.clip(np.abs(arr), 1.0, None))
-    if mode == "inv_y":
-        return 1.0 / np.clip(np.abs(arr), floor, None)
-    raise ValueError(f"unknown mode '{mode}'")
+__all__ = ["noise_weights", "robust_weights", "irls_weights"]

--- a/core/weights.py
+++ b/core/weights.py
@@ -1,0 +1,56 @@
+import numpy as np
+
+
+def noise_weights(y, mode, eps=1e-12):
+    """Return per-point noise weights according to ``mode``.
+
+    Parameters
+    ----------
+    y : array_like
+        Observed data after applying the chosen baseline.
+    mode : {"none", "poisson", "inv_y"}
+        Weighting strategy.
+    eps : float, optional
+        Small positive floor guarding against division by zero.
+    """
+    arr = np.asarray(y, dtype=float)
+    if mode == "none":
+        return np.ones_like(arr)
+    abs_y = np.maximum(np.abs(arr), eps)
+    if mode == "poisson":
+        return 1.0 / np.sqrt(abs_y)
+    if mode == "inv_y":
+        return 1.0 / abs_y
+    raise ValueError(f"unknown mode '{mode}'")
+
+
+def robust_weights(r, loss, f_scale, eps=1e-12):
+    """Return IRLS weights for residuals under ``loss``.
+
+    Parameters
+    ----------
+    r : array_like
+        Residual vector.
+    loss : {"linear", "soft_l1", "huber", "cauchy"}
+        Robust loss name following ``scipy.optimize.least_squares``.
+    f_scale : float
+        Scale parameter for the robust loss.
+    eps : float, optional
+        Small positive value guarding against division by zero.
+    """
+    r = np.asarray(r, dtype=float)
+    fs = float(max(f_scale, eps))
+    z = r / fs
+    if loss == "linear":
+        w = np.ones_like(z)
+    elif loss == "soft_l1":
+        w = (1.0 + z ** 2) ** -0.25
+    elif loss == "huber":
+        w = np.ones_like(z)
+        mask = np.abs(z) > 1.0
+        w[mask] = np.sqrt(1.0 / np.maximum(np.abs(z[mask]), eps))
+    elif loss == "cauchy":
+        w = (1.0 + z ** 2) ** -0.5
+    else:  # pragma: no cover - unknown loss
+        raise ValueError(f"unknown loss '{loss}'")
+    return w

--- a/fit/modern.py
+++ b/fit/modern.py
@@ -9,6 +9,7 @@ from scipy.optimize import least_squares
 
 from core.residuals import build_residual_jac
 from core.models import pv_design_matrix
+from core.weights import noise_weights
 from .bounds import pack_theta_bounds
 from .utils import mad_sigma, robust_cost
 from . import step_engine
@@ -79,11 +80,10 @@ def solve(
     restarts = int(options.get("restarts", 1))
     jitter_pct = float(options.get("jitter_pct", 0.0))
 
-    weights = None if weight_mode == "none" else noise_weights(y, weight_mode)
-
     options = options.copy()
     base = baseline if baseline is not None else 0.0
     y_target = y - base
+    weights = None if weight_mode == "none" else noise_weights(y_target, weight_mode)
     p95 = float(np.percentile(np.abs(y_target), 95)) if y_target.size else 1.0
     max_height_factor = float(options.get("max_height_factor", np.inf))
     options["max_height"] = max_height_factor * p95
@@ -247,7 +247,6 @@ def iterate(state: dict) -> dict:
 
     loss = options.get("loss", "linear")
     weight_mode = options.get("weights", "none")
-    weights = None if weight_mode == "none" else noise_weights(y, weight_mode)
 
     _, bounds = pack_theta_bounds(peaks, x, options)
 
@@ -258,7 +257,7 @@ def iterate(state: dict) -> dict:
         mode,
         baseline,
         loss=loss,
-        weights=weights,
+        weight_mode=weight_mode,
         damping=state.get("lambda", 0.0),
         trust_radius=state.get("trust_radius", np.inf),
         bounds=bounds,

--- a/fit/modern_vp.py
+++ b/fit/modern_vp.py
@@ -7,7 +7,7 @@ import numpy as np
 from scipy.optimize import nnls
 
 from core.models import pv_design_matrix, pv_sum_with_jac
-from core.robust import noise_weights
+from core.weights import noise_weights
 from core.peaks import Peak
 from .bounds import pack_theta_bounds
 from .utils import mad_sigma, robust_cost
@@ -77,11 +77,10 @@ def solve(
     lambda_c = float(options.get("lambda_c", 0.0))
     lambda_w = float(options.get("lambda_w", 0.0))
 
-    weights = None if weight_mode == "none" else noise_weights(y, weight_mode)
-
     options = options.copy()
     base = baseline if baseline is not None else 0.0
     y_target = y - base
+    weights = None if weight_mode == "none" else noise_weights(y_target, weight_mode)
     p95 = float(np.percentile(np.abs(y_target), 95)) if y_target.size else 1.0
     max_height_factor = float(options.get("max_height_factor", np.inf))
     options["max_height"] = max_height_factor * p95
@@ -347,7 +346,6 @@ def iterate(state: dict) -> dict:
 
     loss = options.get("loss", "linear")
     weight_mode = options.get("weights", "none")
-    weights = None if weight_mode == "none" else noise_weights(y, weight_mode)
 
     _, bounds = pack_theta_bounds(peaks, x, options)
 
@@ -358,7 +356,7 @@ def iterate(state: dict) -> dict:
         mode,
         baseline,
         loss=loss,
-        weights=weights,
+        weight_mode=weight_mode,
         damping=state.get("lambda", 0.0),
         trust_radius=state.get("trust_radius", np.inf),
         bounds=bounds,

--- a/tests/test_step_equivalence.py
+++ b/tests/test_step_equivalence.py
@@ -34,7 +34,7 @@ def test_step_converges_close_to_fit():
 
     options = {}
     theta0, bounds = pack_theta_bounds(step_peaks, x, options)
-    weights = None  # no noise weighting
+    weight_mode = "none"  # no noise weighting
 
     model0 = pv_sum(x, step_peaks)
     r0 = model0 - y
@@ -46,7 +46,7 @@ def test_step_converges_close_to_fit():
         "subtract",
         None,
         loss="linear",
-        weights=weights,
+        weight_mode=weight_mode,
         damping=0.0,
         trust_radius=np.inf,
         bounds=bounds,
@@ -65,7 +65,7 @@ def test_step_converges_close_to_fit():
             "subtract",
             None,
             loss="linear",
-            weights=weights,
+            weight_mode=weight_mode,
             damping=0.0,
             trust_radius=np.inf,
             bounds=bounds,

--- a/tests/test_step_weight_modes.py
+++ b/tests/test_step_weight_modes.py
@@ -1,0 +1,31 @@
+import numpy as np
+import pathlib, sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from core.peaks import Peak
+from core.models import pv_sum
+from fit.bounds import pack_theta_bounds
+from fit import step_engine
+
+
+def test_step_weight_modes_smoke():
+    x = np.linspace(-5, 5, 100)
+    peaks = [Peak(0.0, 1.0, 1.0, 0.5)]
+    y = pv_sum(x, peaks)
+    _, bounds = pack_theta_bounds(peaks, x, {})
+    for mode in ["none", "poisson", "inv_y"]:
+        theta, cost = step_engine.step_once(
+            x,
+            y,
+            peaks,
+            "subtract",
+            None,
+            loss="linear",
+            weight_mode=mode,
+            damping=0.0,
+            trust_radius=np.inf,
+            bounds=bounds,
+            f_scale=1.0,
+        )
+        assert np.isfinite(cost)

--- a/tests/test_weights.py
+++ b/tests/test_weights.py
@@ -2,13 +2,13 @@ import numpy as np
 import pathlib, sys
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
-from core.robust import irls_weights
+from core.weights import robust_weights
 
 
-def test_irls_weights_monotonic():
+def test_robust_weights_monotonic():
     r = np.linspace(0.0, 5.0, 50)
     for loss in ["soft_l1", "huber", "cauchy"]:
-        w = irls_weights(r, loss, 1.0)
+        w = robust_weights(r, loss, 1.0)
         assert np.all(w[:-1] >= w[1:])
-    w_lin = irls_weights(r, "linear", 1.0)
+    w_lin = robust_weights(r, "linear", 1.0)
     assert np.allclose(w_lin, 1.0)


### PR DESCRIPTION
## Summary
- introduce `core.weights` with reusable `noise_weights` and `robust_weights`
- apply new helpers across solver backends and step engine, fixing NameError
- step engine now mirrors solver weighting (noise + robust) and new tests cover weight modes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab76ac4dc08330bb5483fbca61b7ae