### PR TITLE
feat: unify solver API with fallback orchestrator

### DIFF
--- a/fit/__init__.py
+++ b/fit/__init__.py
@@ -1,5 +1,129 @@
-"""Solver backends and helpers for Peakfit 3.x."""
+"""Unified solver interface for Peakfit 3.x."""
+from __future__ import annotations
 
+from dataclasses import replace
+from typing import Dict, Callable, Sequence
+
+import numpy as np
+
+from core import models
+from .result import FitResult
 from . import classic, modern, modern_vp, lmfit_backend, step_engine, bounds
 
-__all__ = ["classic", "modern", "modern_vp", "lmfit_backend", "step_engine", "bounds"]
+# Mapping of public solver names to backend implementations.  ``modern`` is the
+# Trust Region Reflective solver; ``modern_vp`` uses variable projection.
+_SOLVERS: Dict[str, Callable] = {
+    "classic": classic.solve,
+    "modern_trf": modern.solve,
+    "modern_vp": modern_vp.solve,
+    "lmfit_vp": lmfit_backend.solve,
+}
+
+_ITERATORS: Dict[str, Callable] = {
+    "classic": classic.iterate,
+    "modern_trf": modern.iterate,
+    "modern_vp": modern_vp.iterate,
+    "lmfit_vp": lmfit_backend.iterate,
+}
+
+__all__ = [
+    "classic",
+    "modern",
+    "modern_vp",
+    "lmfit_backend",
+    "step_engine",
+    "bounds",
+    "solve",
+    "iterate",
+    "FitResult",
+]
+
+
+def _peaks_from_theta(peaks: Sequence, theta: np.ndarray) -> list:
+    """Return deep-copied peaks updated from a flattened ``theta`` vector."""
+
+    out = []
+    for i, pk in enumerate(peaks):
+        c, h, w, e = theta[4 * i : 4 * (i + 1)]
+        # ``replace`` works for both :mod:`core.peaks` and the GUI's dataclass.
+        out.append(
+            replace(
+                pk,
+                center=float(c),
+                height=float(h),
+                fwhm=float(abs(w)),
+                eta=float(e),
+            )
+        )
+    return out
+
+
+def _adapt_result(
+    raw: dict,
+    solver_name: str,
+    x: np.ndarray,
+    y: np.ndarray,
+    peaks: Sequence,
+    mode: str,
+    baseline: np.ndarray | None,
+) -> FitResult:
+    """Convert legacy ``SolveResult`` dictionaries into :class:`FitResult`."""
+
+    theta = np.asarray(raw.get("theta", []), dtype=float)
+    peaks_out = _peaks_from_theta(peaks, theta)
+    base = baseline if baseline is not None else 0.0
+    model = models.pv_sum(x, peaks_out)
+    if mode == "add":
+        resid = model + base - y
+    else:
+        resid = model - (y - base)
+    rmse = float(np.sqrt(np.mean(resid**2))) if resid.size else float("nan")
+    meta = raw.get("meta", {}) or {}
+    nfev = int(meta.get("nfev", 0))
+    n_iter = int(meta.get("n_iter", meta.get("njev", nfev)))
+    return FitResult(
+        success=bool(raw.get("ok", False)),
+        solver=solver_name,
+        theta=theta,
+        peaks_out=peaks_out,
+        cost=float(raw.get("cost", np.nan)),
+        rmse=rmse,
+        nfev=nfev,
+        n_iter=n_iter,
+        message=str(raw.get("message", "")),
+        diagnostics=meta,
+    )
+
+
+def solve(
+    x: np.ndarray,
+    y: np.ndarray,
+    peaks: Sequence,
+    mode: str,
+    baseline: np.ndarray | None,
+    options: dict,
+) -> FitResult:
+    """Dispatch to the selected backend and return a :class:`FitResult`.
+
+    The ``options`` mapping must contain a ``solver`` key identifying the
+    backend (``classic`` | ``modern_vp`` | ``modern_trf`` | ``lmfit_vp``).  Any
+    additional items are forwarded to the backend's native ``solve`` function.
+    """
+
+    solver_name = options.get("solver", "modern_vp")
+    func = _SOLVERS.get(solver_name)
+    if func is None:  # pragma: no cover - defensive programming
+        raise ValueError(f"unknown solver '{solver_name}'")
+    raw = func(x, y, peaks, mode, baseline, options)
+    return _adapt_result(raw, solver_name, x, y, peaks, mode, baseline)
+
+
+def iterate(state: dict) -> dict:
+    """Dispatch to the backend iterate function."""
+
+    opts = state.get("options", {})
+    solver_name = opts.get("solver", "modern_vp")
+    func = _ITERATORS.get(solver_name)
+    if func is None:  # pragma: no cover - defensive programming
+        raise ValueError(f"unknown solver '{solver_name}'")
+    return func(state)

--- a/fit/classic.py
+++ b/fit/classic.py
@@ -185,7 +185,7 @@ def iterate(state: dict) -> dict:
 
     _, bounds = pack_theta_bounds(peaks, x, options)
 
-    theta, cost = step_engine.step_once(
+    theta, cost, step_norm, accepted = step_engine.step_once(
         x,
         y,
         peaks,
@@ -197,9 +197,12 @@ def iterate(state: dict) -> dict:
         trust_radius=state.get("trust_radius", np.inf),
         bounds=bounds,
         f_scale=options.get("f_scale", 1.0),
+        max_backtracks=options.get("max_backtracks", 8),
     )
 
     state["theta"] = theta
     state["cost"] = cost
+    state["step_norm"] = step_norm
+    state["accepted"] = accepted
     return state
 

--- a/fit/lmfit_backend.py
+++ b/fit/lmfit_backend.py
@@ -192,7 +192,7 @@ def iterate(state: dict) -> dict:
 
     _, bounds = pack_theta_bounds(peaks, x, options)
 
-    theta, cost = step_engine.step_once(
+    theta, cost, step_norm, accepted = step_engine.step_once(
         x,
         y,
         peaks,
@@ -204,8 +204,11 @@ def iterate(state: dict) -> dict:
         trust_radius=state.get("trust_radius", np.inf),
         bounds=bounds,
         f_scale=options.get("f_scale", 1.0),
+        max_backtracks=options.get("max_backtracks", 8),
     )
 
     state["theta"] = theta
     state["cost"] = cost
+    state["step_norm"] = step_norm
+    state["accepted"] = accepted
     return state

--- a/fit/modern.py
+++ b/fit/modern.py
@@ -250,7 +250,7 @@ def iterate(state: dict) -> dict:
 
     _, bounds = pack_theta_bounds(peaks, x, options)
 
-    theta, cost = step_engine.step_once(
+    theta, cost, step_norm, accepted = step_engine.step_once(
         x,
         y,
         peaks,
@@ -262,9 +262,12 @@ def iterate(state: dict) -> dict:
         trust_radius=state.get("trust_radius", np.inf),
         bounds=bounds,
         f_scale=options.get("f_scale", 1.0),
+        max_backtracks=options.get("max_backtracks", 8),
     )
 
     state["theta"] = theta
     state["cost"] = cost
+    state["step_norm"] = step_norm
+    state["accepted"] = accepted
     return state
 

--- a/fit/orchestrator.py
+++ b/fit/orchestrator.py
@@ -1,0 +1,69 @@
+"""High level fitting orchestration with solver fallbacks."""
+from __future__ import annotations
+
+from typing import Sequence, List
+
+import numpy as np
+
+from . import solve, iterate
+from .result import FitResult
+
+FALLBACKS = ["modern_vp", "modern_trf", "classic", "lmfit_vp"]
+
+
+def run_fit_with_fallbacks(
+    x: np.ndarray,
+    y: np.ndarray,
+    peaks: Sequence,
+    mode: str,
+    baseline: np.ndarray | None,
+    options: dict,
+) -> FitResult:
+    """Run the requested solver with simple fallbacks.
+
+    Parameters
+    ----------
+    x, y : ``np.ndarray``
+        Data to fit.
+    peaks : sequence
+        Initial peak guesses.
+    mode : {"add", "subtract"}
+        Baseline handling mode.
+    baseline : ``np.ndarray`` or ``None``
+        Baseline array matching ``x`` or ``None``.
+    options : dict
+        Dictionary of solver options.  Must contain a ``solver`` key selecting
+        the primary solver.  Any remaining options are passed through to the
+        backend ``solve`` call.
+    """
+
+    solver = options.get("solver", FALLBACKS[0])
+    order: List[str] = []
+    if solver in FALLBACKS:
+        idx = FALLBACKS.index(solver)
+        order = FALLBACKS[idx:] + FALLBACKS[:idx]
+    else:  # pragma: no cover - defensive
+        order = FALLBACKS
+
+    last: FitResult | None = None
+    msgs: List[str] = []
+    for name in order:
+        opts = dict(options)
+        opts["solver"] = name
+        result = solve(x, y, peaks, mode, baseline, opts)
+        msgs.append(f"{name}:{'ok' if result.success else 'fail'}")
+        if result.success:
+            result.message = (result.message + " | " + " -> ".join(msgs)).strip()
+            return result
+        last = result
+    # If we get here no solver succeeded; return the last result so the caller
+    # still receives diagnostics.
+    assert last is not None  # for type checkers
+    last.message = (last.message + " | " + " -> ".join(msgs)).strip()
+    return last
+
+
+def step_once(state: dict) -> dict:
+    """Run a single solver iteration without fallbacks."""
+
+    return iterate(state)

--- a/fit/result.py
+++ b/fit/result.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+import numpy as np
+
+
+@dataclass
+class FitResult:
+    """Unified solver result.
+
+    All solver backends are adapted to return this dataclass so that the rest of
+    the application can interact with a stable API irrespective of which
+    numerical routine performed the optimisation.
+    """
+
+    success: bool
+    solver: str
+    theta: np.ndarray
+    peaks_out: List[Any]
+    cost: float
+    rmse: float
+    nfev: int
+    n_iter: int
+    message: str = ""
+    diagnostics: Dict[str, Any] = field(default_factory=dict)

--- a/tests/test_orchestrator_smoke.py
+++ b/tests/test_orchestrator_smoke.py
@@ -1,0 +1,32 @@
+import importlib
+import pathlib
+import sys
+
+import numpy as np
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from core import models, peaks
+from fit import orchestrator
+
+
+def synthetic_data():
+    x = np.linspace(-5.0, 5.0, 200)
+    true = [
+        peaks.Peak(-1.0, 1.0, 1.0, 0.3),
+        peaks.Peak(1.2, 0.7, 1.1, 0.5),
+    ]
+    y = models.pv_sum(x, true)
+    return x, y, true
+
+
+def test_fallback_solvers_smoke():
+    x, y, true = synthetic_data()
+    solvers = ["classic", "modern_vp", "modern_trf"]
+    if importlib.util.find_spec("lmfit") is not None:
+        solvers.append("lmfit_vp")
+    for name in solvers:
+        init = [peaks.Peak(p.center + 0.2, p.height * 0.8, p.fwhm * 1.2, p.eta) for p in true]
+        res = orchestrator.run_fit_with_fallbacks(x, y, init, "subtract", None, {"solver": name})
+        assert res.success
+        assert np.isfinite(res.rmse)
+        assert len(res.peaks_out) == len(true)

--- a/tests/test_step_dispatch.py
+++ b/tests/test_step_dispatch.py
@@ -1,0 +1,32 @@
+import numpy as np
+import pathlib, sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from core.peaks import Peak
+from core.models import pv_sum
+from fit import iterate
+
+
+def test_iterate_dispatch_cost_decreases():
+    x = np.linspace(-5, 5, 100)
+    true = [Peak(-1.0, 2.0, 1.0, 0.5)]
+    y = pv_sum(x, true)
+    peaks = [Peak(-0.5, 1.5, 1.2, 0.5)]
+
+    options = {"solver": "classic"}
+    state = {
+        "x_fit": x,
+        "y_fit": y,
+        "peaks": peaks,
+        "mode": "subtract",
+        "baseline": None,
+        "options": options,
+    }
+
+    model0 = pv_sum(x, peaks)
+    cost0 = 0.5 * float(np.sum((model0 - y) ** 2))
+
+    res = iterate(state)
+    assert res["accepted"]
+    assert res["cost"] <= cost0

--- a/tests/test_step_equivalence.py
+++ b/tests/test_step_equivalence.py
@@ -39,7 +39,7 @@ def test_step_converges_close_to_fit():
     model0 = pv_sum(x, step_peaks)
     r0 = model0 - y
     cost0 = 0.5 * float(np.dot(r0, r0))
-    theta, cost1 = step_engine.step_once(
+    theta, cost1, step_norm, accepted = step_engine.step_once(
         x,
         y,
         step_peaks,
@@ -52,13 +52,13 @@ def test_step_converges_close_to_fit():
         bounds=bounds,
         f_scale=1.0,
     )
-    assert cost1 < cost0
+    assert accepted and cost1 < cost0
     lb, ub = bounds
     assert np.all(theta >= lb) and np.all(theta <= ub)
     _update_peaks(step_peaks, theta)
 
     for _ in range(19):
-        theta, cost1 = step_engine.step_once(
+        theta, cost1, step_norm, accepted = step_engine.step_once(
             x,
             y,
             step_peaks,

--- a/tests/test_step_weight_modes.py
+++ b/tests/test_step_weight_modes.py
@@ -15,7 +15,7 @@ def test_step_weight_modes_smoke():
     y = pv_sum(x, peaks)
     _, bounds = pack_theta_bounds(peaks, x, {})
     for mode in ["none", "poisson", "inv_y"]:
-        theta, cost = step_engine.step_once(
+        theta, cost, step_norm, accepted = step_engine.step_once(
             x,
             y,
             peaks,
@@ -28,4 +28,4 @@ def test_step_weight_modes_smoke():
             bounds=bounds,
             f_scale=1.0,
         )
-        assert np.isfinite(cost)
+        assert accepted and np.isfinite(cost)


### PR DESCRIPTION
## Summary
- add step iteration dispatcher so Step ▶ uses same solver APIs
- implement backtracking step engine with diagnostics and NNLS refresh for modern VP
- wire GUI Step ▶ to dispatcher and surface backend/step telemetry

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab87463124833083a46113e428106f