### PR TITLE
Clamp Classic solver with data-driven bounds

### DIFF
--- a/core/bounds.py
+++ b/core/bounds.py
@@ -1,0 +1,173 @@
+import numpy as np
+
+
+def make_bounds(peaks, x, fit_mask=None, *, bound_centers_to_window=True,
+                max_fwhm_factor=0.5, max_height_factor=2.0, y_target=None, **opts):
+    x = np.asarray(x, dtype=float)
+    if fit_mask is not None and np.any(fit_mask):
+        x_fit = x[fit_mask]
+    else:
+        x_fit = x
+    x_fit = np.asarray(x_fit, dtype=float)
+    xmin = float(np.min(x_fit)) if x_fit.size else 0.0
+    xmax = float(np.max(x_fit)) if x_fit.size else 0.0
+    if x_fit.size > 1:
+        dx = float(np.median(np.diff(np.sort(x_fit))))
+    else:
+        dx = 1.0
+    fwhm_min = max(2.0 * dx, 1e-6)
+    span = xmax - xmin
+    if span > 0:
+        fwhm_max = max_fwhm_factor * span
+    else:
+        fwhm_max = np.inf
+
+    if 'max_height' in opts and opts['max_height'] is not None:
+        h_cap = float(opts['max_height'])
+    elif y_target is not None and np.asarray(y_target).size:
+        y_arr = np.asarray(y_target, dtype=float)
+        p95 = float(np.nanpercentile(np.abs(y_arr), 95))
+        h_cap = max_height_factor * max(p95, 1e-9)
+    else:
+        h_cap = np.inf
+
+    lo = []
+    hi = []
+    for pk in peaks:
+        # height
+        lo.append(0.0)
+        hi.append(h_cap)
+        # center
+        if getattr(pk, 'lock_center', False):
+            lo.append(-np.inf)
+            hi.append(np.inf)
+        else:
+            if bound_centers_to_window:
+                lo.append(xmin)
+                hi.append(xmax)
+            else:
+                pad = 0.1 * span
+                lo.append(xmin - pad)
+                hi.append(xmax + pad)
+        # width
+        if getattr(pk, 'lock_width', False):
+            lo.append(1e-6)
+            hi.append(np.inf)
+        else:
+            lo.append(fwhm_min)
+            hi.append(fwhm_max if np.isfinite(fwhm_max) else np.inf)
+    lo = np.asarray(lo, dtype=float)
+    hi = np.asarray(hi, dtype=float)
+    lo[~np.isfinite(lo)] = -1e12
+    hi[~np.isfinite(hi)] = 1e12
+    hi = np.maximum(hi, lo + 1e-12)
+    info = dict(fwhm_min=fwhm_min, fwhm_max=fwhm_max, h_cap=h_cap, xmin=xmin, xmax=xmax)
+    return (lo, hi), info
+
+
+def make_bounds_classic(x, y, peaks, fit_mask=None, cfg=None):
+    """Return bounds and clipped start vector for the Classic solver.
+
+    Parameters
+    ----------
+    x, y : array-like
+        Data coordinates and target intensities (baseline already applied as
+        required).  ``y`` may be ``None`` when only geometric bounds are
+        desired.
+    peaks : sequence
+        Initial peak guesses.
+    fit_mask : array-like or ``None``
+        Boolean mask selecting the active fitting window within ``x``.
+    cfg : mapping
+        Classic configuration with keys ``bound_centers_to_window``,
+        ``fwhm_min_dx_factor``, ``fwhm_max_span_factor`` and
+        ``max_height_factor``.
+
+    Returns
+    -------
+    (lo, hi) : tuple of ``np.ndarray``
+        Lower and upper bounds for the flattened parameter vector ordered as
+        ``[c, h, w, eta, ...]``.
+    theta0 : ``np.ndarray``
+        Starting parameter vector clipped into ``[lo, hi]``.
+    """
+
+    cfg = cfg or {}
+    x = np.asarray(x, dtype=float)
+    y = np.asarray(y, dtype=float) if y is not None else np.array([], dtype=float)
+
+    if fit_mask is not None and np.any(fit_mask):
+        x_fit = x[fit_mask]
+        y_fit = y[fit_mask] if y.size else y
+    else:
+        x_fit = x
+        y_fit = y
+
+    xmin = float(np.min(x_fit)) if x_fit.size else 0.0
+    xmax = float(np.max(x_fit)) if x_fit.size else 0.0
+    span = xmax - xmin
+    dx = float(np.median(np.diff(np.sort(x_fit)))) if x_fit.size > 1 else 1.0
+
+    wmin = max(float(cfg.get("fwhm_min_dx_factor", 2.0)) * dx, 1e-6)
+    wmax = (
+        float(cfg.get("fwhm_max_span_factor", 0.5)) * span if span > 0 else np.inf
+    )
+
+    if y_fit.size:
+        p95 = float(np.nanpercentile(y_fit, 95))
+        p05 = float(np.nanpercentile(y_fit, 5))
+        hmax = float(cfg.get("max_height_factor", 3.0)) * max(p95 - p05, 1e-9)
+    else:
+        hmax = np.inf
+
+    bound_centers = bool(cfg.get("bound_centers_to_window", True))
+
+    lo = []
+    hi = []
+    theta0 = []
+    for pk in peaks:
+        c = float(pk.center)
+        h = float(pk.height)
+        w = float(pk.fwhm)
+        e = float(pk.eta)
+
+        if getattr(pk, "lock_center", False):
+            lo_c = hi_c = c
+        else:
+            if bound_centers:
+                lo_c, hi_c = xmin, xmax
+            else:
+                pad = span
+                lo_c, hi_c = xmin - pad, xmax + pad
+            c = float(np.clip(c, lo_c, hi_c))
+
+        if getattr(pk, "lock_height", False):
+            lo_h = hi_h = h
+        else:
+            lo_h, hi_h = 0.0, hmax
+            h = float(np.clip(h, lo_h, hi_h))
+
+        if getattr(pk, "lock_width", False):
+            lo_w = hi_w = w
+        else:
+            lo_w, hi_w = wmin, wmax
+            w = float(np.clip(w, lo_w, hi_w))
+
+        lo_e, hi_e = 0.0, 1.0
+        e = float(np.clip(e, lo_e, hi_e))
+
+        theta0.extend([c, h, w, e])
+        lo.extend([lo_c, lo_h, lo_w, lo_e])
+        hi.extend([hi_c, hi_h, hi_w, hi_e])
+
+    lo = np.asarray(lo, dtype=float)
+    hi = np.asarray(hi, dtype=float)
+    theta0 = np.asarray(theta0, dtype=float)
+
+    lo[~np.isfinite(lo)] = -1e12
+    hi[~np.isfinite(hi)] = 1e12
+    hi = np.maximum(hi, lo + 1e-12)
+    theta0[~np.isfinite(theta0)] = 0.0
+    theta0 = np.minimum(np.maximum(theta0, lo), hi)
+
+    return (lo, hi), theta0

--- a/core/residuals.py
+++ b/core/residuals.py
@@ -67,11 +67,15 @@ def build_residual_jac(
     mode: str,
     baseline: np.ndarray | None,
     weights: np.ndarray | None,
+    wmin_eval: float = 0.0,
+    clip_heights: bool = False,
 ) -> Callable[[np.ndarray], tuple[np.ndarray, np.ndarray]]:
     """Return residual and Jacobian builder for solvers.
 
     The parameter vector ``theta`` follows the order ``[h1,(c1),(w1), h2,(c2),(w2), ...]``
-    where centres and widths are omitted when locked.
+    where centres and widths are omitted when locked.  ``wmin_eval`` provides a
+    minimum width used only for evaluation to guard against invalid intermediate
+    values; ``clip_heights`` enforces non-negative amplitudes when set.
     """
 
     x = np.asarray(x, dtype=float)
@@ -104,6 +108,10 @@ def build_residual_jac(
             if not lock_w[i]:
                 f[i] = theta[j]
                 j += 1
+        if clip_heights:
+            h = np.maximum(h, 0.0)
+        if wmin_eval > 0.0:
+            f = np.maximum(f, wmin_eval)
 
         model = np.zeros_like(x)
         cols = []

--- a/fit/classic.py
+++ b/fit/classic.py
@@ -10,7 +10,7 @@ from scipy.optimize import least_squares
 from core.residuals import build_residual_jac
 from core.models import pv_design_matrix
 from core.weights import noise_weights
-from .bounds import pack_theta_bounds
+from core.bounds import make_bounds_classic
 from . import step_engine
 
 
@@ -24,7 +24,7 @@ class SolveResult(TypedDict):
     meta: dict
 
 
-def _to_solver_vectors(theta0: np.ndarray, bounds, peaks, fwhm_min: float):
+def _to_solver_vectors(theta0: np.ndarray, bounds, peaks, wmin_eval: float):
     lb, ub = bounds
     theta_list = []
     lb_list = []
@@ -43,14 +43,14 @@ def _to_solver_vectors(theta0: np.ndarray, bounds, peaks, fwhm_min: float):
             theta_list.append(c)
             lb_list.append(lb[4 * i + 0])
             ub_list.append(ub[4 * i + 0])
-            x_scale.append(max(theta0[4 * i + 2], fwhm_min))
+            x_scale.append(max(theta0[4 * i + 2], wmin_eval))
             indices.append(4 * i + 0)
         if not p.lock_width:
             w = theta0[4 * i + 2]
             theta_list.append(w)
             lb_list.append(lb[4 * i + 2])
             ub_list.append(ub[4 * i + 2])
-            x_scale.append(max(w, fwhm_min))
+            x_scale.append(max(w, wmin_eval))
             indices.append(4 * i + 2)
     return (
         np.asarray(theta_list, dtype=float),
@@ -73,19 +73,25 @@ def solve(
     baseline = np.asarray(baseline, dtype=float) if baseline is not None else None
 
     weight_mode = options.get("weights", "none")
+    cfg = {
+        "bound_centers_to_window": options.get("bound_centers_to_window", True),
+        "fwhm_min_dx_factor": options.get("fwhm_min_dx_factor", 2.0),
+        "fwhm_max_span_factor": options.get("fwhm_max_span_factor", 0.5),
+        "max_height_factor": options.get("max_height_factor", 3.0),
+    }
 
-    options = options.copy()
-    base = baseline if baseline is not None else 0.0
-    y_target = y - base
+    if mode == "add":
+        y_target = y
+    else:
+        base = baseline if baseline is not None else 0.0
+        y_target = y - base
     weights = None if weight_mode == "none" else noise_weights(y_target, weight_mode)
-    p95 = float(np.percentile(np.abs(y_target), 95)) if y_target.size else 1.0
-    max_height_factor = float(options.get("max_height_factor", np.inf))
-    options["max_height"] = max_height_factor * p95
-    options["max_fwhm"] = options.get("max_fwhm", 0.5 * (x.max() - x.min()))
 
-    theta0_full, bounds_full = pack_theta_bounds(peaks, x, options)
-    dx_med = float(np.median(np.diff(x))) if x.size > 1 else 1.0
-    fwhm_min = max(float(options.get("min_fwhm", 1e-6)), 2.0 * dx_med)
+    (lb_full, ub_full), theta0_full = make_bounds_classic(
+        x, y_target, peaks, None, cfg
+    )
+
+    wmin_eval = float(lb_full[2]) if theta0_full.size >= 3 else 1e-6
 
     all_locked = all(p.lock_center and p.lock_width for p in peaks)
 
@@ -105,7 +111,8 @@ def solve(
         cost = 0.5 * float(r @ r)
         theta_full = theta0_full.copy()
         for i, val in enumerate(h):
-            theta_full[4 * i + 1] = val
+            idx = 4 * i + 1
+            theta_full[idx] = float(np.clip(val, lb_full[idx], ub_full[idx]))
         jac = Aw if weights is not None else A
         return SolveResult(
             ok=True,
@@ -117,8 +124,12 @@ def solve(
             meta={"nfev": 1},
         )
 
-    theta0, bounds, x_scale, indices = _to_solver_vectors(theta0_full, bounds_full, peaks, fwhm_min)
-    resid_jac = build_residual_jac(x, y, peaks, mode, baseline, weights)
+    theta0, bounds, x_scale, indices = _to_solver_vectors(
+        theta0_full, (lb_full, ub_full), peaks, wmin_eval
+    )
+    resid_jac = build_residual_jac(
+        x, y, peaks, mode, baseline, weights, wmin_eval=wmin_eval, clip_heights=True
+    )
 
     def fun(t):
         r, _ = resid_jac(t)
@@ -144,6 +155,7 @@ def solve(
     ok = bool(res.success)
     theta_full = theta0_full.copy()
     theta_full[indices] = res.x
+    theta_full = np.minimum(np.maximum(theta_full, lb_full), ub_full)
     jac_full = res.jac
     cov = None
     if jac_full is not None:
@@ -179,11 +191,24 @@ def iterate(state: dict) -> dict:
     mode = state.get("mode", "subtract")
     baseline = state.get("baseline")
     options = state.get("options", {})
-
-    loss = options.get("loss", "linear")
     weight_mode = options.get("weights", "none")
-
-    _, bounds = pack_theta_bounds(peaks, x, options)
+    cfg = {
+        "bound_centers_to_window": options.get("bound_centers_to_window", True),
+        "fwhm_min_dx_factor": options.get("fwhm_min_dx_factor", 2.0),
+        "fwhm_max_span_factor": options.get("fwhm_max_span_factor", 0.5),
+        "max_height_factor": options.get("max_height_factor", 3.0),
+    }
+    if mode == "add":
+        y_target = y
+    else:
+        base = baseline if baseline is not None else 0.0
+        y_target = y - base
+    (lb, ub), theta0 = make_bounds_classic(x, y_target, peaks, None, cfg)
+    for i, pk in enumerate(peaks):
+        pk.center = theta0[4 * i + 0]
+        pk.height = theta0[4 * i + 1]
+        pk.fwhm = theta0[4 * i + 2]
+        pk.eta = theta0[4 * i + 3]
 
     theta, cost, step_norm, accepted = step_engine.step_once(
         x,
@@ -191,11 +216,11 @@ def iterate(state: dict) -> dict:
         peaks,
         mode,
         baseline,
-        loss=loss,
+        loss="linear",
         weight_mode=weight_mode,
         damping=state.get("lambda", 0.0),
         trust_radius=state.get("trust_radius", np.inf),
-        bounds=bounds,
+        bounds=(lb, ub),
         f_scale=options.get("f_scale", 1.0),
         max_backtracks=options.get("max_backtracks", 8),
     )

--- a/fit/modern.py
+++ b/fit/modern.py
@@ -128,7 +128,9 @@ def solve(
     best_cost = np.inf
     rng = np.random.default_rng(options.get("seed"))
 
-    resid_jac = build_residual_jac(x, y, peaks, mode, baseline, weights)
+    resid_jac = build_residual_jac(
+        x, y, peaks, mode, baseline, weights
+    )
 
     for _ in range(max(1, restarts)):
         if jitter_pct:

--- a/infra/config.py
+++ b/infra/config.py
@@ -14,6 +14,13 @@ DEFAULT_CONFIG: Dict[str, Any] = {
         "save_traces": False,
         "auto_max": 5,
     },
+    "classic": {
+        "maxfev": 20000,
+        "bound_centers_to_window": True,
+        "fwhm_min_dx_factor": 2.0,
+        "fwhm_max_span_factor": 0.5,
+        "max_height_factor": 3.0,
+    },
 }
 
 

--- a/tests/test_classic_bounds.py
+++ b/tests/test_classic_bounds.py
@@ -1,0 +1,57 @@
+import numpy as np
+import pathlib, sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from core.peaks import Peak
+from core.models import pv_sum
+from fit import classic
+
+
+def test_classic_respects_bounds():
+    x = np.linspace(0, 10, 200)
+    peaks = [Peak(2.0, 1.0, 0.5, 0.5), Peak(5.0, 0.8, 0.4, 0.5)]
+    y = pv_sum(x, peaks)
+    res = classic.solve(x, y, peaks, "subtract", None, {})
+    centers = res["theta"][0::4]
+    widths = res["theta"][2::4]
+    xmin, xmax = float(x.min()), float(x.max())
+    dx = float(np.median(np.diff(x))) if x.size > 1 else 1.0
+    fwhm_min = max(2.0 * dx, 1e-6)
+    fwhm_max = 0.5 * (xmax - xmin)
+    assert np.all(centers >= xmin) and np.all(centers <= xmax)
+    assert np.all(widths >= fwhm_min) and np.all(widths <= fwhm_max)
+    assert res["ok"] and np.isfinite(res["cost"])
+
+
+def test_classic_lock_respected():
+    x = np.linspace(0, 3, 100)
+    peaks = [
+        Peak(1.0, 1.0, 0.2, 0.5, lock_center=True, lock_width=True),
+        Peak(2.0, 0.8, 0.3, 0.5),
+    ]
+    y = pv_sum(x, peaks)
+    res = classic.solve(x, y, peaks, "subtract", None, {})
+    theta = res["theta"]
+    assert np.isclose(theta[0], 1.0)
+    assert np.isclose(theta[2], 0.2)
+
+
+def test_classic_clamps_bad_start():
+    x = np.linspace(0, 1, 200)
+    true = [Peak(0.3, 1.0, 0.05, 0.5), Peak(0.7, 0.8, 0.04, 0.5)]
+    y = pv_sum(x, true)
+    start = [Peak(5.0, 1.0, 1.0, 0.5), Peak(-3.0, 0.5, 2.0, 0.5)]
+    model0 = pv_sum(x, start)
+    cost0 = 0.5 * float(np.dot(model0 - y, model0 - y))
+    res = classic.solve(x, y, start, "subtract", None, {})
+    theta = res["theta"]
+    centers = theta[0::4]
+    widths = theta[2::4]
+    xmin, xmax = float(x.min()), float(x.max())
+    dx = float(np.median(np.diff(x))) if x.size > 1 else 1.0
+    fwhm_min = max(2.0 * dx, 1e-6)
+    fwhm_max = 0.5 * (xmax - xmin)
+    assert np.all(centers >= xmin) and np.all(centers <= xmax)
+    assert np.all(widths >= fwhm_min) and np.all(widths <= fwhm_max)
+    assert res["cost"] < cost0

--- a/tests/test_solver_stability.py
+++ b/tests/test_solver_stability.py
@@ -1,0 +1,25 @@
+import numpy as np
+import pathlib, sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from core import models, peaks
+from fit import orchestrator
+
+
+def test_modern_and_lmfit_stable():
+    x = np.linspace(-5.0, 5.0, 200)
+    true = [peaks.Peak(-1.0, 1.0, 1.0, 0.3), peaks.Peak(1.2, 0.7, 1.1, 0.5)]
+    y = models.pv_sum(x, true)
+    init = [peaks.Peak(p.center + 0.2, p.height * 0.8, p.fwhm * 1.2, p.eta) for p in true]
+    expected = np.array([-1.0, 1.0, 1.0, 0.3, 1.2, 0.7, 1.1, 0.5])
+    solvers = ["modern_vp", "modern_trf"]
+    try:
+        import lmfit  # noqa: F401
+        solvers.append("lmfit_vp")
+    except Exception:
+        pass
+    for name in solvers:
+        res = orchestrator.run_fit_with_fallbacks(x, y, init, "subtract", None, {"solver": name})
+        assert np.allclose(res.theta, expected, atol=1e-12)
+        assert res.cost < 1e-12

--- a/ui/app.py
+++ b/ui/app.py
@@ -249,6 +249,10 @@ class PeakFitApp:
         self.bootstrap_solver_label = tk.StringVar(value=SOLVER_LABELS[self.solver_choice.get()])
         self.solver_title = tk.StringVar(value=SOLVER_LABELS[self.solver_choice.get()])
         self.classic_maxfev = tk.IntVar(value=20000)
+        self.classic_centers_window = tk.BooleanVar(value=True)
+        self.classic_fwhm_min_dx = tk.DoubleVar(value=2.0)
+        self.classic_fwhm_max_span = tk.DoubleVar(value=0.5)
+        self.classic_max_height = tk.DoubleVar(value=3.0)
         self.modern_loss = tk.StringVar(value="linear")
         self.modern_weight = tk.StringVar(value="none")
         self.modern_fscale = tk.DoubleVar(value=1.0)
@@ -463,8 +467,20 @@ class PeakFitApp:
 
         # Classic options
         f_classic = ttk.Frame(opts_parent)
-        ttk.Label(f_classic, text="Max evals").pack(side=tk.LEFT)
-        ttk.Entry(f_classic, width=7, textvariable=self.classic_maxfev).pack(side=tk.LEFT, padx=4)
+        rowc = ttk.Frame(f_classic)
+        rowc.pack(anchor="w")
+        ttk.Label(rowc, text="Max evals").pack(side=tk.LEFT)
+        ttk.Entry(rowc, width=7, textvariable=self.classic_maxfev).pack(side=tk.LEFT, padx=4)
+        ttk.Checkbutton(f_classic, text="Centers in window", variable=self.classic_centers_window).pack(anchor="w")
+        row1 = ttk.Frame(f_classic); row1.pack(anchor="w")
+        ttk.Label(row1, text="Min FWHM×Δx").pack(side=tk.LEFT)
+        ttk.Entry(row1, width=4, textvariable=self.classic_fwhm_min_dx).pack(side=tk.LEFT, padx=2)
+        row2 = ttk.Frame(f_classic); row2.pack(anchor="w")
+        ttk.Label(row2, text="Max span frac").pack(side=tk.LEFT)
+        ttk.Entry(row2, width=4, textvariable=self.classic_fwhm_max_span).pack(side=tk.LEFT, padx=2)
+        row3 = ttk.Frame(f_classic); row3.pack(anchor="w")
+        ttk.Label(row3, text="Max height ×").pack(side=tk.LEFT)
+        ttk.Entry(row3, width=4, textvariable=self.classic_max_height).pack(side=tk.LEFT, padx=2)
         self.solver_frames["classic"] = f_classic
 
         # Modern options (shared for VP and TRF)
@@ -612,7 +628,13 @@ class PeakFitApp:
                 "share_fwhm": bool(self.lmfit_share_fwhm.get()),
                 "share_eta": bool(self.lmfit_share_eta.get()),
             }
-        return {"maxfev": int(self.classic_maxfev.get())}
+        return {
+            "maxfev": int(self.classic_maxfev.get()),
+            "bound_centers_to_window": bool(self.classic_centers_window.get()),
+            "fwhm_min_dx_factor": float(self.classic_fwhm_min_dx.get()),
+            "fwhm_max_span_factor": float(self.classic_fwhm_max_span.get()),
+            "max_height_factor": float(self.classic_max_height.get()),
+        }
 
     def _on_solver_change(self):
         choice = self.solver_choice.get()


### PR DESCRIPTION
## Summary
- add `make_bounds_classic` to compute data-driven limits for centers, widths, and heights
- apply new bounds and residual guardrails in Classic solver and Step ▶ path
- expose Classic-only bound options in config and UI
- verify Classic clamps bad starts and other solvers remain stable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab91e5436c8330b7008f8abad8f7b6