### PR TITLE
Enable performance toggles and parallel bootstrap

### DIFF
--- a/fit/classic.py
+++ b/fit/classic.py
@@ -7,7 +7,7 @@ import numpy as np
 from scipy.optimize import curve_fit
 
 from core.peaks import Peak
-from core.models import pv_sum
+from infra import performance as perf
 
 W_MIN = 1e-6  # minimal physical FWHM
 
@@ -114,7 +114,8 @@ def _build_residual(
             w = s["w_fixed"] if s["iw"] is None else theta_free[s["iw"]]
             w = max(w, W_MIN)
             peaks.append(Peak(c, h, w, s["eta"]))
-        model = pv_sum(x_fit, peaks)
+        pk_tuples = [(p.height, p.center, p.fwhm, p.eta) for p in peaks]
+        model = perf.eval_total(x_fit, pk_tuples)
         if base_fit is not None:
             model = model + base_fit
         return model - y_target
@@ -147,7 +148,8 @@ def solve(x, y, peaks, mode, baseline, opts):
             w = s["w_fixed"] if s["iw"] is None else theta[s["iw"]]
             w = max(w, W_MIN)
             peaks_loc.append(Peak(c, h, w, s["eta"]))
-        model = pv_sum(xdata, peaks_loc)
+        pk_tuples = [(p.height, p.center, p.fwhm, p.eta) for p in peaks_loc]
+        model = perf.eval_total(xdata, pk_tuples)
         if base_fit is not None:
             model = model + base_fit
         return model
@@ -161,7 +163,8 @@ def solve(x, y, peaks, mode, baseline, opts):
     rmse = float(np.sqrt(np.mean(resid_final**2)))
     peaks_out = _theta_to_peaks(popt, struct)
     theta_full = _theta_full(popt, struct)
-    model_full = pv_sum(x, peaks_out)
+    pk_tuples = [(p.height, p.center, p.fwhm, p.eta) for p in peaks_out]
+    model_full = perf.eval_total(x, pk_tuples)
     if mode == "add" and base is not None:
         y_fit = model_full + base
     else:

--- a/fit/modern.py
+++ b/fit/modern.py
@@ -8,7 +8,7 @@ import numpy as np
 from scipy.optimize import least_squares
 
 from core.residuals import build_residual_jac
-from core.models import pv_design_matrix
+from infra import performance as perf
 from core.weights import noise_weights
 from core.peaks import Peak
 from .bounds import pack_theta_bounds
@@ -96,7 +96,8 @@ def solve(
 
     all_locked = all(p.lock_center and p.lock_width for p in peaks)
     if all_locked:
-        A = pv_design_matrix(x, peaks)
+        unit_peaks = [(1.0, p.center, p.fwhm, p.eta) for p in peaks]
+        A = perf.design_matrix(x, unit_peaks)
         if weights is not None:
             Aw = A * weights[:, None]
             yw = y_target * weights

--- a/infra/performance.py
+++ b/infra/performance.py
@@ -1,78 +1,351 @@
-"""Performance configuration for Peakfit 3.x."""
+"""Defensive performance layer with optional Numba/CuPy backends.
+
+All public evaluators return ``np.ndarray`` with ``dtype=float64``.  The
+selected backend is one of ``{"numpy", "numba", "cupy"}`` and can be
+switched at runtime.  When shadow-compare is enabled (either explicitly or
+via ``GL_PERF_SHADOW_COMPARE``), the fast path is cross-checked against the
+NumPy reference; on any mismatch a single warning is logged and the backend
+permanently falls back to NumPy for the remainder of the process.
+
+The math mirrors the pseudo-Voigt formula used throughout the GUI and keeps
+summation order deterministic by stacking components and using ``np.sum``.
+"""
+
 from __future__ import annotations
 
-from typing import Optional
+import math
+import os
+from typing import Callable, Optional
 
 import numpy as np
-import random
 
-from core import models
+# ---------------------------------------------------------------------------
+# Optional dependencies
+try:  # pragma: no cover - optional import
+    import numba as _numba
+    _NUMBA_OK = True
+except Exception:  # pragma: no cover - numba not available
+    _numba = None
+    _NUMBA_OK = False
 
-_numba_enabled = False
-_gpu_enabled = False
-_max_workers = 0
-_cache_baseline = True
-_gpu_chunk = 262144
+try:  # pragma: no cover - optional import
+    import cupy as _cp
+    _CUPY_OK = True
+except Exception:  # pragma: no cover - cupy not available
+    _cp = None
+    _CUPY_OK = False
 
 
-def set_numba(flag: bool) -> None:
-    """Enable or disable Numba acceleration if available."""
+# ---------------------------------------------------------------------------
+# Global state controlled via setters
+_NUMBA_USER = False
+_GPU_USER = False
+_BACKEND = "numpy"
 
-    global _numba_enabled
-    try:  # pragma: no cover - optional dependency
-        import numba  # noqa: F401
+_CACHE_BASELINE = True
+_MAX_WORKERS = 0
+_SEED: Optional[int] = None
+_GPU_CHUNK = 262_144
 
-        _numba_enabled = bool(flag)
+_LOG: Optional[Callable[[str, str], None]] = None
+
+_SHADOW_COMPARE = False
+_SHADOW_RTOL = 1e-10
+_SHADOW_ATOL = 1e-12
+_SHADOW_WARNED = False
+
+
+# ---------------------------------------------------------------------------
+# Logger helpers
+def set_logger(fn: Optional[Callable[[str, str], None]]) -> None:
+    """Register a logger callback ``fn(message, level)``."""
+
+    global _LOG
+    _LOG = fn
+
+
+def _log(msg: str, level: str = "INFO") -> None:
+    if _LOG is None:
+        return
+    try:  # pragma: no cover - defensive
+        _LOG(msg, level)
     except Exception:
-        _numba_enabled = False
+        pass
 
 
-def set_gpu(flag: bool) -> None:
-    """Enable or disable CuPy GPU acceleration."""
-
-    global _gpu_enabled
-    if flag and models.cp is not None:
-        models.xp = models.cp
-        _gpu_enabled = True
+# ---------------------------------------------------------------------------
+# Backend management
+def _update_backend() -> None:
+    global _BACKEND
+    if _GPU_USER and _CUPY_OK:
+        _BACKEND = "cupy"
+    elif _NUMBA_USER and _NUMBA_OK:
+        _BACKEND = "numba"
     else:
-        models.xp = np
-        _gpu_enabled = False
+        _BACKEND = "numpy"
+
+
+def set_numba(enabled: bool) -> None:
+    """Enable Numba JIT backend when available."""
+
+    global _NUMBA_USER
+    _NUMBA_USER = bool(enabled) and _NUMBA_OK
+    if enabled and not _NUMBA_OK:
+        _log("Numba not available; running on NumPy.", "WARN")
+    if _NUMBA_USER:
+        _warmup_numba()
+    _update_backend()
+
+
+def set_gpu(enabled: bool) -> None:
+    """Enable CuPy GPU backend when available."""
+
+    global _GPU_USER
+    _GPU_USER = bool(enabled) and _CUPY_OK
+    if enabled and not _CUPY_OK:
+        _log("CuPy not available; GPU disabled.", "WARN")
+    if _GPU_USER:
+        try:  # pragma: no cover - GPU initialisation
+            _warmup_gpu()
+        except Exception:
+            _GPU_USER = False
+            _log("CuPy GPU init failed; falling back to NumPy.", "WARN")
+    _update_backend()
+
+
+def set_cache_baseline(enabled: bool) -> None:
+    global _CACHE_BASELINE
+    _CACHE_BASELINE = bool(enabled)
+
+
+def cache_baseline_enabled() -> bool:
+    return _CACHE_BASELINE
 
 
 def set_seed(seed: Optional[int]) -> None:
-    """Seed all random number generators for determinism."""
-
-    np.random.seed(seed if seed is not None else None)
-    random.seed(seed)
-    if models.cp is not None:
-        try:  # pragma: no cover - CuPy may be absent
-            models.cp.random.seed(seed)
+    global _SEED
+    _SEED = int(seed) if seed is not None else None
+    if _SEED is None:
+        return
+    np.random.seed(_SEED)
+    if _CUPY_OK:  # pragma: no cover - optional
+        try:
+            _cp.random.seed(_SEED)
         except Exception:
             pass
 
 
 def set_max_workers(n: int) -> None:
-    """Set the maximum number of parallel workers."""
-
-    global _max_workers
-    _max_workers = max(0, int(n))
+    global _MAX_WORKERS
+    _MAX_WORKERS = max(0, int(n))
 
 
-def set_cache_baseline(flag: bool) -> None:
-    """Enable or disable ALS baseline caching."""
-
-    global _cache_baseline
-    _cache_baseline = bool(flag)
-
-
-def cache_baseline_enabled() -> bool:
-    """Return True if baseline caching is enabled."""
-
-    return _cache_baseline
+def get_max_workers() -> int:
+    return _MAX_WORKERS
 
 
 def set_gpu_chunk(n: int) -> None:
-    """Configure chunk size for GPU evaluations."""
+    global _GPU_CHUNK
+    _GPU_CHUNK = max(16_384, int(n))
 
-    global _gpu_chunk
-    _gpu_chunk = max(1, int(n))
+
+def which_backend() -> str:
+    return _BACKEND
+
+
+def enable_shadow_compare(flag: bool, rtol: float = 1e-10, atol: float = 1e-12) -> None:
+    global _SHADOW_COMPARE, _SHADOW_RTOL, _SHADOW_ATOL
+    _SHADOW_COMPARE = bool(flag)
+    _SHADOW_RTOL = float(rtol)
+    _SHADOW_ATOL = float(atol)
+
+
+def _shadow_fail() -> None:
+    """Handle shadow-compare mismatch by logging and falling back to NumPy."""
+
+    global _SHADOW_WARNED, _NUMBA_USER, _GPU_USER
+    if not _SHADOW_WARNED:
+        _log("Performance backend mismatch; falling back to NumPy.", "WARN")
+        _SHADOW_WARNED = True
+    _NUMBA_USER = False
+    _GPU_USER = False
+    _update_backend()
+
+
+# Enable shadow compare if environment variable is set ----------------------
+if os.getenv("GL_PERF_SHADOW_COMPARE", "").strip():  # pragma: no cover - env hook
+    enable_shadow_compare(True)
+
+
+# ---------------------------------------------------------------------------
+# Core math kernels
+def _pvoigt_np(x, h, c, w, eta):
+    w = 1e-12 if w < 1e-12 else w
+    eta = 0.0 if eta < 0.0 else 1.0 if eta > 1.0 else eta
+    dx = (x - c) / w
+    ga = np.exp(-4.0 * np.log(2.0) * dx * dx)
+    lo = 1.0 / (1.0 + 4.0 * dx * dx)
+    return h * ((1.0 - eta) * ga + eta * lo)
+
+
+if _NUMBA_OK:  # pragma: no cover - JIT definitions
+    @_numba.njit(cache=True)
+    def _pvoigt_nb(x, h, c, w, eta):  # type: ignore
+        w = 1e-12 if w < 1e-12 else w
+        if eta < 0.0:
+            eta = 0.0
+        elif eta > 1.0:
+            eta = 1.0
+        dx = (x - c) / w
+        ga = np.exp(-4.0 * np.log(2.0) * dx * dx)
+        lo = 1.0 / (1.0 + 4.0 * dx * dx)
+        return h * ((1.0 - eta) * ga + eta * lo)
+
+
+def _pvoigt_cp(x_cp, h, c, w, eta):  # pragma: no cover - GPU path
+    w = 1e-12 if w < 1e-12 else w
+    eta = 0.0 if eta < 0.0 else 1.0 if eta > 1.0 else eta
+    dx = (x_cp - c) / w
+    ga = _cp.exp(-4.0 * math.log(2.0) * dx * dx)
+    lo = 1.0 / (1.0 + 4.0 * dx * dx)
+    return h * ((1.0 - eta) * ga + eta * lo)
+
+
+# ---------------------------------------------------------------------------
+# Backend-specific evaluators
+def _eval_components_numpy(x, peaks):
+    comps = [
+        _pvoigt_np(x, h, c, w, eta) for (h, c, w, eta) in peaks
+    ]
+    if comps:
+        return np.vstack(comps).astype(np.float64, copy=False)
+    return np.zeros((0, x.size), dtype=np.float64)
+
+
+def _eval_total_numpy(x, peaks):
+    comps = _eval_components_numpy(x, peaks)
+    if comps.size:
+        return np.sum(comps, axis=0, dtype=np.float64)
+    return np.zeros_like(x, dtype=np.float64)
+
+
+def _eval_components_numba(x, peaks):
+    n = len(peaks)
+    comps = np.empty((n, x.size), dtype=np.float64)
+    for i, (h, c, w, eta) in enumerate(peaks):
+        comps[i] = _pvoigt_nb(x, h, c, w, eta)
+    return comps
+
+
+def _eval_total_numba(x, peaks):
+    comps = _eval_components_numba(x, peaks)
+    if comps.size:
+        return np.sum(comps, axis=0, dtype=np.float64)
+    return np.zeros_like(x, dtype=np.float64)
+
+
+def _eval_components_gpu(x, peaks):  # pragma: no cover - GPU path
+    xp = _cp
+    x_cp = xp.asarray(x, dtype=xp.float64)
+    comps = []
+    for h, c, w, eta in peaks:
+        comps.append(_pvoigt_cp(x_cp, h, c, w, eta))
+    if comps:
+        C = xp.stack(comps)
+        return np.asarray(xp.asnumpy(C), dtype=np.float64)
+    return np.zeros((0, x_cp.size), dtype=np.float64)
+
+
+def _eval_total_gpu(x, peaks):  # pragma: no cover - GPU path
+    xp = _cp
+    x_cp = xp.asarray(x, dtype=xp.float64)
+    y = xp.zeros_like(x_cp, dtype=xp.float64)
+    for h, c, w, eta in peaks:
+        y += _pvoigt_cp(x_cp, h, c, w, eta)
+    return np.asarray(xp.asnumpy(y), dtype=np.float64)
+
+
+def _eval_components_backend(x, peaks):
+    if _BACKEND == "cupy":
+        return _eval_components_gpu(x, peaks)
+    if _BACKEND == "numba":
+        return _eval_components_numba(x, peaks)
+    return _eval_components_numpy(x, peaks)
+
+
+def _eval_total_backend(x, peaks):
+    if _BACKEND == "cupy":
+        return _eval_total_gpu(x, peaks)
+    if _BACKEND == "numba":
+        return _eval_total_numba(x, peaks)
+    return _eval_total_numpy(x, peaks)
+
+
+# ---------------------------------------------------------------------------
+# Public evaluators
+def eval_total(x: np.ndarray, peaks) -> np.ndarray:
+    """Evaluate the sum of pseudo-Voigt peaks on ``x``."""
+
+    x = np.asarray(x, dtype=np.float64)
+    fast = _eval_total_backend(x, peaks)
+    if _SHADOW_COMPARE and _BACKEND != "numpy":
+        ref = _eval_total_numpy(x, peaks)
+        if not np.allclose(fast, ref, rtol=_SHADOW_RTOL, atol=_SHADOW_ATOL):
+            _shadow_fail()
+            return ref
+    return fast.astype(np.float64, copy=False)
+
+
+def eval_components(x: np.ndarray, peaks) -> np.ndarray:
+    """Return component matrix with shape ``(n_peaks, len(x))``."""
+
+    x = np.asarray(x, dtype=np.float64)
+    fast = _eval_components_backend(x, peaks)
+    if _SHADOW_COMPARE and _BACKEND != "numpy":
+        ref = _eval_components_numpy(x, peaks)
+        if not np.allclose(fast, ref, rtol=_SHADOW_RTOL, atol=_SHADOW_ATOL):
+            _shadow_fail()
+            return ref
+    return fast.astype(np.float64, copy=False)
+
+
+def design_matrix(x: np.ndarray, peaks) -> np.ndarray:
+    """Return design matrix ``A`` with columns per peak (shape ``m×n``)."""
+
+    comps = eval_components(x, peaks)
+    return comps.T.astype(np.float64, copy=False)
+
+
+# ---------------------------------------------------------------------------
+# Warmups to trigger JIT/initial allocations
+def _warmup_numba() -> None:  # pragma: no cover - warmup only
+    if not _NUMBA_OK:
+        return
+    x = np.linspace(0.0, 1.0, 8)
+    _ = _pvoigt_nb(x, 1.0, 0.5, 0.1, 0.5)
+
+
+def _warmup_gpu() -> None:  # pragma: no cover - warmup only
+    if not _CUPY_OK:
+        return
+    x = _cp.linspace(0.0, 1.0, 8)
+    _ = _pvoigt_cp(x, 1.0, 0.5, 0.1, 0.5)
+
+
+__all__ = [
+    "set_numba",
+    "set_gpu",
+    "set_cache_baseline",
+    "set_seed",
+    "set_max_workers",
+    "get_max_workers",
+    "set_gpu_chunk",
+    "set_logger",
+    "which_backend",
+    "eval_total",
+    "eval_components",
+    "design_matrix",
+    "enable_shadow_compare",
+    "cache_baseline_enabled",
+]
+

--- a/tests/test_bootstrap_workers.py
+++ b/tests/test_bootstrap_workers.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import pathlib
+import numpy as np
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from core.peaks import Peak
+from core.residuals import build_residual
+from infra import performance
+from uncertainty import bootstrap as bs
+
+pytestmark = pytest.mark.filterwarnings("ignore:.*")
+
+
+def test_bootstrap_parallel_deterministic():
+    performance.set_seed(123)
+    performance.set_max_workers(2)
+
+    x = np.linspace(-1, 1, 20)
+    peaks = [Peak(0.0, 1.0, 0.5, 0.2)]
+    y_true = performance.eval_total(x, [(1.0, 0.0, 0.5, 0.2)])
+    noise = np.linspace(0, 1e-3, x.size)
+    y = y_true + noise
+
+    resid_fn = build_residual(x, y, peaks, "add", None, "linear", None)
+    theta = np.array([0.0, 1.0, 0.5, 0.2])
+    cfg = dict(x=x, y=y, peaks=peaks, mode="add", baseline=None, theta=theta, options={}, n=4, seed=1)
+
+    res1 = bs.bootstrap("classic", cfg, resid_fn)
+    res2 = bs.bootstrap("classic", cfg, resid_fn)
+
+    assert np.allclose(res1["params"]["samples"], res2["params"]["samples"])
+    performance.set_max_workers(0)
+

--- a/tests/test_cache_flag.py
+++ b/tests/test_cache_flag.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import pathlib
+import numpy as np
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from infra import performance
+
+pytestmark = pytest.mark.filterwarnings("ignore:.*")
+
+
+def test_cache_flag_controls_calls():
+    calls = []
+
+    def fake_als(y, lam=1, p=0.5, niter=10, tol=1e-3):
+        calls.append(1)
+        return np.zeros_like(y)
+
+    data = np.ones(5)
+    cache = {}
+
+    def compute():
+        key = 0 if performance.cache_baseline_enabled() else None
+        if key is not None and key in cache:
+            return cache[key]
+        res = fake_als(data)
+        if key is not None:
+            cache[key] = res
+        return res
+
+    performance.set_cache_baseline(True)
+    compute()
+    compute()
+    assert len(calls) == 1
+
+    calls.clear()
+    cache.clear()
+    performance.set_cache_baseline(False)
+    compute()
+    compute()
+    assert len(calls) == 2
+
+    performance.set_cache_baseline(True)
+

--- a/tests/test_performance_backend.py
+++ b/tests/test_performance_backend.py
@@ -1,0 +1,82 @@
+import pathlib
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from infra import performance
+
+pytestmark = pytest.mark.filterwarnings("ignore:.*")
+
+
+def _reference_components(x, peaks):
+    comps = []
+    for h, c, w, eta in peaks:
+        w = max(w, 1e-12)
+        eta = min(1.0, max(0.0, eta))
+        dx = (x - c) / w
+        ga = np.exp(-4.0 * np.log(2.0) * dx * dx)
+        lo = 1.0 / (1.0 + 4.0 * dx * dx)
+        comps.append(h * ((1.0 - eta) * ga + eta * lo))
+    if comps:
+        return np.vstack(comps)
+    return np.zeros((0, x.size))
+
+
+def _run_backend_check():
+    x = np.linspace(-1, 1, 100)
+    peaks = [(1.0, -0.2, 0.5, 0.2), (0.7, 0.3, 0.4, 0.6)]
+    ref_comps = _reference_components(x, peaks)
+    ref_total = ref_comps.sum(axis=0)
+
+    y = performance.eval_total(x, peaks)
+    comps = performance.eval_components(x, peaks)
+    A = performance.design_matrix(x, peaks)
+
+    assert y.dtype == np.float64
+    assert comps.dtype == np.float64
+    assert A.dtype == np.float64
+    assert comps.shape == (len(peaks), x.size)
+    assert A.shape == (x.size, len(peaks))
+
+    assert np.allclose(y, ref_total, rtol=1e-10, atol=1e-12)
+    assert np.allclose(comps, ref_comps, rtol=1e-10, atol=1e-12)
+    assert np.allclose(A, ref_comps.T, rtol=1e-10, atol=1e-12)
+
+
+def test_numpy_backend_matches_reference():
+    performance.set_numba(False)
+    performance.set_gpu(False)
+    _run_backend_check()
+    assert performance.which_backend() == "numpy"
+
+
+@pytest.mark.skipif(not getattr(performance, "_NUMBA_OK", False), reason="Numba not available")
+def test_numba_backend_agrees():
+    performance.set_gpu(False)
+    performance.set_numba(True)
+    if performance.which_backend() != "numba":
+        pytest.skip("Numba not usable")
+    _run_backend_check()
+    performance.set_numba(False)
+
+
+@pytest.mark.skipif(not getattr(performance, "_CUPY_OK", False), reason="CuPy not available")
+def test_gpu_backend_agrees():
+    performance.set_numba(False)
+    performance.set_gpu(True)
+    if performance.which_backend() != "cupy":
+        pytest.skip("CuPy not usable")
+    _run_backend_check()
+    performance.set_gpu(False)
+
+
+@pytest.mark.skipif(
+    performance.which_backend() == "cupy"
+    or not getattr(performance, "_CUPY_OK", False),
+    reason="CuPy not available",
+)
+def test_gpu_skipped():
+    assert True
+

--- a/tests/test_performance_components.py
+++ b/tests/test_performance_components.py
@@ -1,0 +1,50 @@
+import pathlib
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from infra import performance
+
+pytestmark = pytest.mark.filterwarnings("ignore:.*")
+
+x = np.linspace(-1, 1, 50)
+peaks = [(1.0, -0.1, 0.4, 0.3), (0.5, 0.2, 0.2, 0.6)]
+
+
+def _check_components():
+    comps = performance.eval_components(x, peaks)
+    total = performance.eval_total(x, peaks)
+    A = performance.design_matrix(x, peaks)
+    assert comps.shape == (len(peaks), x.size)
+    assert A.shape == (x.size, len(peaks))
+    assert np.allclose(comps.sum(axis=0), total, rtol=1e-10, atol=1e-12)
+    assert np.allclose(A, comps.T, rtol=1e-10, atol=1e-12)
+
+
+def test_components_numpy():
+    performance.set_numba(False)
+    performance.set_gpu(False)
+    _check_components()
+
+
+@pytest.mark.skipif(not getattr(performance, "_NUMBA_OK", False), reason="Numba not available")
+def test_components_numba():
+    performance.set_gpu(False)
+    performance.set_numba(True)
+    if performance.which_backend() != "numba":
+        pytest.skip("Numba not usable")
+    _check_components()
+    performance.set_numba(False)
+
+
+@pytest.mark.skipif(not getattr(performance, "_CUPY_OK", False), reason="CuPy not available")
+def test_components_gpu():
+    performance.set_numba(False)
+    performance.set_gpu(True)
+    if performance.which_backend() != "cupy":
+        pytest.skip("CuPy not usable")
+    _check_components()
+    performance.set_gpu(False)
+

--- a/tests/test_shadow_compare.py
+++ b/tests/test_shadow_compare.py
@@ -1,0 +1,61 @@
+import importlib
+import pathlib
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+pytestmark = pytest.mark.filterwarnings("ignore:.*")
+
+
+def _reload_performance(monkeypatch):
+    import infra.performance as performance
+    return importlib.reload(performance)
+
+
+def test_shadow_compare_ok(monkeypatch):
+    monkeypatch.delenv("GL_PERF_SHADOW_COMPARE", raising=False)
+    performance = _reload_performance(monkeypatch)
+    logs = []
+    performance.set_logger(lambda m, lvl="INFO": logs.append((lvl, m)))
+    performance.enable_shadow_compare(True)
+    performance.set_numba(False)
+    performance.set_gpu(False)
+    x = np.linspace(-1, 1, 20)
+    peaks = [(1.0, 0.0, 0.5, 0.3), (0.8, 0.4, 0.2, 0.5)]
+    y = performance.eval_total(x, peaks)
+    comps = performance.eval_components(x, peaks)
+    assert np.allclose(comps.sum(axis=0), y)
+    assert logs == []
+    performance.enable_shadow_compare(False)
+    performance.set_logger(None)
+
+
+@pytest.mark.skipif(not getattr(importlib.import_module("infra.performance"), "_NUMBA_OK", False), reason="Numba not available")
+def test_shadow_compare_warns_and_falls_back(monkeypatch):
+    monkeypatch.setenv("GL_PERF_SHADOW_COMPARE", "1")
+    performance = _reload_performance(monkeypatch)
+    if not performance._NUMBA_OK:
+        pytest.skip("Numba not available")
+    logs = []
+    performance.set_logger(lambda m, lvl="INFO": logs.append((lvl, m)))
+    performance.set_gpu(False)
+    performance.set_numba(True)
+
+    orig = performance._eval_total_numba
+
+    def bad_eval(x, peaks):
+        y = orig(x, peaks)
+        y[0] += 1e-6
+        return y
+
+    monkeypatch.setattr(performance, "_eval_total_numba", bad_eval)
+    x = np.linspace(-1, 1, 20)
+    peaks = [(1.0, 0.0, 0.5, 0.3)]
+    performance.eval_total(x, peaks)
+    assert logs and logs[0][0] == "WARN"
+    assert performance.which_backend() == "numpy"
+    performance.set_logger(None)
+

--- a/tests/test_solver_parity.py
+++ b/tests/test_solver_parity.py
@@ -1,0 +1,59 @@
+import sys
+import pathlib
+import numpy as np
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from infra import performance
+from core.peaks import Peak
+
+pytestmark = pytest.mark.filterwarnings("ignore:.*")
+
+
+def _reference_total(x, peaks):
+    y = np.zeros_like(x, dtype=float)
+    for h, c, w, eta in peaks:
+        w = max(w, 1e-12)
+        eta = min(1.0, max(0.0, eta))
+        dx = (x - c) / w
+        ga = np.exp(-4.0 * np.log(2.0) * dx * dx)
+        lo = 1.0 / (1.0 + 4.0 * dx * dx)
+        y += h * ((1.0 - eta) * ga + eta * lo)
+    return y
+
+
+def _rmse(theta, x, y):
+    n = theta.size // 4
+    pk = [(theta[4*i+1], theta[4*i+0], theta[4*i+2], theta[4*i+3]) for i in range(n)]
+    y_fit = _reference_total(x, pk)
+    return float(np.sqrt(np.mean((y_fit - y) ** 2)))
+
+
+@pytest.mark.parametrize("solver", ["classic", "modern_trf", "modern_vp"])
+def test_solver_parity(solver):
+    performance.set_gpu(False)
+    performance.set_numba(False)
+    x = np.linspace(-1, 1, 100)
+    true_peaks = [
+        Peak(-0.2, 1.0, 0.3, 0.2),
+        Peak(0.0, 0.8, 0.25, 0.5),
+        Peak(0.15, 0.6, 0.2, 0.3),
+    ]
+    y = _reference_total(x, [(p.height, p.center, p.fwhm, p.eta) for p in true_peaks])
+    init = [Peak(p.center, p.height, p.fwhm, p.eta) for p in true_peaks]
+    if solver == "classic":
+        from fit.classic import solve
+    elif solver == "modern_trf":
+        from fit.modern import solve
+    else:
+        from fit.modern_vp import solve
+    res1 = solve(x, y, [Peak(p.center, p.height, p.fwhm, p.eta) for p in init], "add", None, {})
+    theta1 = np.asarray(res1["theta"], dtype=float)
+    rmse1 = _rmse(theta1, x, y)
+    performance.set_numba(True)
+    res2 = solve(x, y, [Peak(p.center, p.height, p.fwhm, p.eta) for p in init], "add", None, {})
+    theta2 = np.asarray(res2["theta"], dtype=float)
+    rmse2 = _rmse(theta2, x, y)
+    assert np.allclose(theta1, theta2, rtol=5e-8, atol=1e-10)
+    assert abs(rmse1 - rmse2) <= 1e-10
+    performance.set_numba(False)

--- a/ui/app.py
+++ b/ui/app.py
@@ -486,6 +486,8 @@ class PeakFitApp:
         self.root = root
         self.root.title("Interactive Peak Fit (pseudo-Voigt)")
 
+        performance.set_logger(self.log_threadsafe)
+
         # Data
         self.x = None
         self.y_raw = None
@@ -2292,6 +2294,7 @@ class PeakFitApp:
         else:
             performance.set_max_workers(0)
         performance.set_gpu_chunk(self.gpu_chunk_var.get())
+        self.log(f"Backend: {performance.which_backend()} | workers={performance.get_max_workers()}")
         self.status_var.set("Performance options applied.")
 
     def on_export(self):


### PR DESCRIPTION
## Summary
- centralize model evaluation in a pluggable `infra.performance` layer with logger-aware backend switches, shadow-compare fallback, and a new `design_matrix` helper
- route residuals and solvers through the performance API to keep orientation consistent while preserving NumPy semantics
- add regression tests exercising backend parity, component orientation, shadow-compare fallback, and solver consistency

## Testing
- `python -m pip install -q numpy scipy pandas matplotlib`
- `python -m pip install -q numba`
- `python -m pip install -q cupy-cuda12x`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae41067bb8833087440ef28174a036