### PR TITLE
Add persistent uncertainty exports and performance config

### DIFF
--- a/batch/runner.py
+++ b/batch/runner.py
@@ -12,10 +12,61 @@ import glob
 from pathlib import Path
 from typing import Iterable, Sequence, List
 
+import math
 import numpy as np
+import pandas as pd
 
 from core import data_io, models, peaks, signals
+from core.residuals import build_residual, jacobian_fd
 from fit import orchestrator
+
+
+def _asymptotic_uncertainty(x, y_target, baseline, fitted, mode):
+    try:
+        theta = []
+        for p in fitted:
+            theta.extend([p.center, p.height, p.fwhm, p.eta])
+        theta = np.asarray(theta, float)
+        resid_fn = build_residual(x, y_target, fitted, mode, baseline, "linear", None)
+        J = jacobian_fd(resid_fn, theta)
+        r0 = resid_fn(theta)
+        rss = float(np.dot(r0, r0))
+        m = r0.size
+        jtj = J.T @ J
+        try:
+            cov = np.linalg.inv(jtj)
+        except np.linalg.LinAlgError:
+            cov = np.linalg.pinv(jtj)
+        dof = max(m - theta.size, 1)
+        sigma2 = rss / dof
+        cov *= sigma2
+        sigma = np.sqrt(np.diag(cov))
+
+        def ymodel(th):
+            tmp = []
+            for i in range(len(fitted)):
+                c, h, w, e = th[4 * i : 4 * i + 4]
+                tmp.append(peaks.Peak(c, h, w, e))
+            total = models.pv_sum(x, tmp)
+            if baseline is not None:
+                total = total + baseline
+            return total
+
+        y0 = ymodel(theta)
+        G = np.empty((x.size, theta.size), float)
+        for j in range(theta.size):
+            step = 1e-6 * max(1.0, abs(theta[j]))
+            tp = theta.copy()
+            tp[j] += step
+            G[:, j] = (ymodel(tp) - y0) / step
+        var = np.einsum('ij,jk,ik->i', G, cov, G)
+        band_std = np.sqrt(np.maximum(var, 0.0))
+        z = 1.96
+        lo = y0 - z * band_std
+        hi = y0 + z * band_std
+        return sigma, (x, lo, hi, y0), {"dof": dof, "s2": sigma2, "rmse": math.sqrt(rss / m)}
+    except Exception:
+        return np.full(4 * len(fitted), np.nan), None, {"dof": np.nan, "s2": np.nan, "rmse": np.nan}
 
 
 def _auto_seed(x: np.ndarray, y: np.ndarray, baseline: np.ndarray, max_peaks: int = 5) -> List[peaks.Peak]:
@@ -80,6 +131,7 @@ def run(patterns: Iterable[str], config: dict, progress=None, log=None) -> None:
     auto_max = int(config.get("auto_max", 5))
 
     records = []
+    unc_rows = []
     ok = 0
 
     for i, path in enumerate(files, 1):
@@ -123,6 +175,20 @@ def run(patterns: Iterable[str], config: dict, progress=None, log=None) -> None:
         rmse = float(np.sqrt(np.mean(resid**2)))
         areas = [models.pv_area(p.height, p.fwhm, p.eta) for p in fitted]
         total = sum(areas) or 1.0
+        perf_extras = {
+            "perf_numba": bool(config.get("perf_numba", False)),
+            "perf_gpu": bool(config.get("perf_gpu", False)),
+            "perf_cache_baseline": bool(config.get("perf_cache_baseline", True)),
+            "perf_seed_all": bool(config.get("perf_seed_all", False)),
+            "perf_max_workers": int(config.get("perf_max_workers", 0)),
+        }
+        center_bounds = (
+            (float(x[0]), float(x[-1]))
+            if (opts.get("centers_in_window") or opts.get("bound_centers_to_window"))
+            else (np.nan, np.nan)
+        )
+        med_dx = float(np.median(np.diff(np.sort(x)))) if x.size > 1 else 0.0
+        fwhm_lo = opts.get("min_fwhm", max(1e-6, 2.0 * med_dx))
         for idx, (p, area) in enumerate(zip(fitted, areas), start=1):
             records.append(
                 {
@@ -143,13 +209,73 @@ def run(patterns: Iterable[str], config: dict, progress=None, log=None) -> None:
                     "als_p": base_cfg.get("p"),
                     "fit_xmin": float(x[0]),
                     "fit_xmax": float(x[-1]),
+                    "solver_choice": solver_name,
+                    "solver_loss": opts.get("loss", np.nan),
+                    "solver_weight": opts.get("weights", np.nan),
+                    "solver_fscale": opts.get("f_scale", np.nan),
+                    "solver_maxfev": opts.get("maxfev", np.nan),
+                    "solver_restarts": opts.get("restarts", np.nan),
+                    "solver_jitter_pct": opts.get("jitter_pct", np.nan),
+                    "use_baseline": True,
+                    "baseline_mode": mode,
+                    "baseline_uses_fit_range": bool(config.get("baseline_uses_fit_range", True)),
+                    "als_niter": base_cfg.get("niter"),
+                    "als_thresh": base_cfg.get("thresh"),
+                    **perf_extras,
+                    "bounds_center_lo": center_bounds[0],
+                    "bounds_center_hi": center_bounds[1],
+                    "bounds_fwhm_lo": fwhm_lo,
+                    "bounds_height_lo": 0.0,
+                    "bounds_height_hi": np.nan,
+                    "x_scale": opts.get("x_scale", np.nan),
                 }
             )
+
+        if res.success:
+            y_target = y if mode == "add" else y - baseline
+            base_resid = baseline if mode == "add" else None
+            sigma, _band, info = _asymptotic_uncertainty(x, y_target, base_resid, fitted, mode)
+        else:
+            sigma = np.full(4 * len(fitted), np.nan)
+            info = {"dof": np.nan, "rmse": rmse}
+        z = 1.96
+        for idx, p in enumerate(fitted, start=1):
+            sc = sigma[4 * (idx - 1)] if sigma.size >= 4 * idx else np.nan
+            sh = sigma[4 * (idx - 1) + 1] if sigma.size >= 4 * idx + 1 else np.nan
+            sf = sigma[4 * (idx - 1) + 2] if sigma.size >= 4 * idx + 2 else np.nan
+            if p.lock_center:
+                sc = np.nan
+            if p.lock_width:
+                sf = np.nan
+            params = [
+                ("center", p.center, sc, not p.lock_center),
+                ("height", p.height, sh, True),
+                ("fwhm", p.fwhm, sf, not p.lock_width),
+                ("eta", p.eta, np.nan, False),
+            ]
+            for pname, val, std, free in params:
+                if free and np.isfinite(std):
+                    ci_lo, ci_hi = val - z * std, val + z * std
+                else:
+                    ci_lo = ci_hi = np.nan
+                unc_rows.append(
+                    {
+                        "file": Path(path).name,
+                        "peak": idx,
+                        "param": pname,
+                        "value": val,
+                        "ci_lo": ci_lo,
+                        "ci_hi": ci_hi,
+                        "method": "asymptotic",
+                        "rmse": rmse,
+                        "dof": info.get("dof", np.nan),
+                    }
+                )
 
         trace_path = None
         if save_traces:
             trace_csv = data_io.build_trace_table(
-                x, y, baseline, fitted, mode=mode
+                x, y, baseline, fitted
             )
             trace_path = Path(path).with_suffix(Path(path).suffix + ".trace.csv")
             with trace_path.open("w", encoding="utf-8") as fh:
@@ -165,5 +291,9 @@ def run(patterns: Iterable[str], config: dict, progress=None, log=None) -> None:
     peak_csv = data_io.build_peak_table(records)
     with open(peak_output, "w", encoding="utf-8") as fh:
         fh.write(peak_csv)
+    unc_output = config.get("unc_output")
+    if not unc_output:
+        unc_output = Path(peak_output).with_name(Path(peak_output).stem + "_uncertainty.csv")
+    pd.DataFrame(unc_rows).to_csv(unc_output, index=False)
 
     return ok, total

--- a/core/data_io.py
+++ b/core/data_io.py
@@ -10,6 +10,7 @@ from typing import Iterable, Tuple
 import csv
 import io
 import re
+from pathlib import Path
 import numpy as np
 
 
@@ -57,6 +58,23 @@ def load_xy(path: str) -> Tuple[np.ndarray, np.ndarray]:
     return x, y
 
 
+def derive_export_paths(user_path: str) -> dict:
+    """Return canonical export file paths based on ``user_path``.
+
+    ``user_path`` may have any extension; the returned paths drop the
+    extension and append ``_fit.csv``, ``_trace.csv`` and
+    ``_uncertainty.txt``.
+    """
+
+    p = Path(user_path)
+    base = p.with_suffix("")
+    return {
+        "fit": base.with_name(base.name + "_fit.csv"),
+        "trace": base.with_name(base.name + "_trace.csv"),
+        "unc_txt": base.with_name(base.name + "_uncertainty.txt"),
+    }
+
+
 def build_peak_table(records: Iterable[dict]) -> str:
     """Return a CSV-formatted peak table built from ``records``.
 
@@ -82,6 +100,29 @@ def build_peak_table(records: Iterable[dict]) -> str:
         "als_p",
         "fit_xmin",
         "fit_xmax",
+        "solver_choice",
+        "solver_loss",
+        "solver_weight",
+        "solver_fscale",
+        "solver_maxfev",
+        "solver_restarts",
+        "solver_jitter_pct",
+        "use_baseline",
+        "baseline_mode",
+        "baseline_uses_fit_range",
+        "als_niter",
+        "als_thresh",
+        "perf_numba",
+        "perf_gpu",
+        "perf_cache_baseline",
+        "perf_seed_all",
+        "perf_max_workers",
+        "bounds_center_lo",
+        "bounds_center_hi",
+        "bounds_fwhm_lo",
+        "bounds_height_lo",
+        "bounds_height_hi",
+        "x_scale",
     ]
     buf = io.StringIO()
     writer = csv.DictWriter(buf, fieldnames=headers, extrasaction="ignore")
@@ -96,49 +137,34 @@ def build_trace_table(
     y_raw: np.ndarray,
     baseline: np.ndarray | None,
     peaks: Iterable,
-    mode: str = "add",
 ) -> str:
-    """Return a CSV trace table for the current fit.
+    """Return a CSV trace table matching the v2.7 schema.
 
-    Parameters
-    ----------
-    x, y_raw:
-        Input data arrays.
-    baseline:
-        Baseline array or ``None``.
-    peaks:
-        Iterable of peak-like objects. Each contributes its own column.
-    mode:
-        ``"add"`` or ``"subtract"`` — controls how the fitted target and
-        model columns are formed.
+    Columns (in order): ``x, y_raw, baseline, y_target_add, y_fit_add,``
+    per-peak additive components, ``y_target_sub, y_fit_sub`` and per-peak
+    subtractive components. The builder always emits both additive and
+    subtractive sections even when no peaks are present.
     """
 
     x = np.asarray(x, dtype=float)
     y_raw = np.asarray(y_raw, dtype=float)
-    base = np.asarray(baseline, dtype=float) if baseline is not None else 0.0
+    base = np.asarray(baseline, dtype=float) if baseline is not None else np.zeros_like(x)
 
-    # per-peak contributions
-    comps = []
     from .models import pv_sum  # local import to avoid cycles
 
-    for p in peaks:
-        comps.append(pv_sum(x, [p]))
-
+    comps = [pv_sum(x, [p]) for p in peaks]
     comps_arr = np.vstack(comps) if comps else np.empty((0, x.size))
     model = comps_arr.sum(axis=0) if comps else np.zeros_like(x)
 
-    if mode == "add":
-        y_target = y_raw
-        y_fit = model + base
-    elif mode == "subtract":
-        y_target = y_raw - base
-        y_fit = model
-    else:  # pragma: no cover - unknown mode
-        raise ValueError("unknown mode")
+    y_target_add = y_raw
+    y_fit_add = model + base
+    y_target_sub = y_raw - base
+    y_fit_sub = model
 
-    headers = ["x", "y_raw", "baseline", "y_target", "y_fit"] + [
-        f"peak{i+1}" for i in range(comps_arr.shape[0])
-    ]
+    headers = ["x", "y_raw", "baseline", "y_target_add", "y_fit_add"]
+    headers += [f"peak{i+1}" for i in range(comps_arr.shape[0])]
+    headers += ["y_target_sub", "y_fit_sub"]
+    headers += [f"peak{i+1}_sub" for i in range(comps_arr.shape[0])]
 
     buf = io.StringIO()
     writer = csv.writer(buf)
@@ -147,11 +173,14 @@ def build_trace_table(
         row = [
             x[idx],
             y_raw[idx],
-            base[idx] if baseline is not None else 0.0,
-            y_target[idx],
-            y_fit[idx],
+            base[idx],
+            y_target_add[idx],
+            y_fit_add[idx],
         ]
-        row.extend(comps_arr[:, idx])
+        row.extend(comps_arr[:, idx] if comps else [])
+        row.append(y_target_sub[idx])
+        row.append(y_fit_sub[idx])
+        row.extend(comps_arr[:, idx] if comps else [])
         writer.writerow(row)
     return buf.getvalue()
 

--- a/tests/test_batch_uncertainty_summary.py
+++ b/tests/test_batch_uncertainty_summary.py
@@ -1,0 +1,58 @@
+import sys
+import pathlib
+import numpy as np
+import pandas as pd
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from batch import runner
+from core.peaks import Peak
+from ui.app import pseudo_voigt  # noqa: E402
+
+
+def test_batch_uncertainty_summary(tmp_path):
+    x = np.linspace(-5, 5, 101)
+    peak = Peak(0.0, 1.0, 1.0, 0.5)
+    y = pseudo_voigt(x, peak.height, peak.center, peak.fwhm, peak.eta)
+    for i in range(2):
+        arr = np.column_stack([x, y])
+        np.savetxt(tmp_path / f"s{i}.csv", arr, delimiter=",")
+
+    cfg = {
+        "peaks": [peak.__dict__],
+        "solver": "classic",
+        "mode": "add",
+        "baseline": {"lam": 1e5, "p": 0.001, "niter": 10, "thresh": 0.0},
+        "save_traces": False,
+        "peak_output": str(tmp_path / "batch_fit.csv"),
+        "unc_output": str(tmp_path / "batch_uncertainty.csv"),
+        "source": "template",
+        "reheight": False,
+        "auto_max": 5,
+        "classic": {},
+        "baseline_uses_fit_range": True,
+        "perf_numba": False,
+        "perf_gpu": False,
+        "perf_cache_baseline": True,
+        "perf_seed_all": False,
+        "perf_max_workers": 0,
+    }
+
+    runner.run([str(tmp_path / "*.csv")], cfg)
+
+    fit_df = pd.read_csv(tmp_path / "batch_fit.csv")
+    for col in [
+        "solver_choice",
+        "solver_loss",
+        "solver_weight",
+        "solver_fscale",
+        "solver_maxfev",
+        "solver_restarts",
+        "solver_jitter_pct",
+        "baseline_uses_fit_range",
+        "perf_numba",
+    ]:
+        assert col in fit_df.columns
+
+    unc_df = pd.read_csv(tmp_path / "batch_uncertainty.csv")
+    assert set(unc_df.columns) == {"file", "peak", "param", "value", "ci_lo", "ci_hi", "method", "rmse", "dof"}
+    assert len(unc_df) == 2 * 1 * 4

--- a/tests/test_config_persistence_perf_unc.py
+++ b/tests/test_config_persistence_perf_unc.py
@@ -1,0 +1,47 @@
+import os
+import sys
+import pathlib
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from ui import app as app_module  # noqa: E402
+
+headless = (os.environ.get("DISPLAY", "") == "" and os.name != "nt")
+if headless:
+    pytest.skip("Skipping GUI tests in headless environment", allow_module_level=True)
+
+tk = pytest.importorskip("tkinter")
+
+
+def test_config_persistence_perf_unc(tmp_path, monkeypatch):
+    cfg_path = tmp_path / "cfg.json"
+    monkeypatch.setattr(app_module, "CONFIG_PATH", cfg_path)
+
+    root = tk.Tk(); root.withdraw()
+    app = app_module.PeakFitApp(root)
+    app.perf_numba.set(True)
+    app.perf_gpu.set(True)
+    app.perf_cache_baseline.set(False)
+    app.perf_seed_all.set(True)
+    app.perf_max_workers.set(5)
+    app.show_ci_band_var.set(False)
+    app.toggle_components()
+    app.show_legend_var.set(False)
+    app._on_legend_toggle()
+    root.destroy()
+
+    root2 = tk.Tk(); root2.withdraw()
+    app2 = app_module.PeakFitApp(root2)
+    cfg = app_module.load_config()
+    assert cfg["perf_numba"] is True
+    assert cfg["perf_gpu"] is True
+    assert cfg["perf_cache_baseline"] is False
+    assert cfg["perf_seed_all"] is True
+    assert cfg["perf_max_workers"] == 5
+    assert cfg["ui_show_uncertainty_band"] is False
+    assert cfg["ui_show_components"] is False
+    assert cfg["ui_show_legend"] is False
+    assert app2.show_ci_band_var.get() is False
+    assert app2.components_visible is False
+    assert app2.show_legend_var.get() is False
+    root2.destroy()


### PR DESCRIPTION
## Summary
- persist uncertainty, baseline range and performance toggles with new defaults
- compute asymptotic uncertainty after each fit and export CI bands & stats
- streamline UI with top-right action bar and compact axes/labels panel
- initialize config early and migrate missing keys to avoid startup crashes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aeb4e7c64483308c5b410368e88b70