### PR TITLE
Add persistent uncertainty exports and performance config

### DIFF
--- a/batch/runner.py
+++ b/batch/runner.py
@@ -12,10 +12,62 @@ import glob
 from pathlib import Path
 from typing import Iterable, Sequence, List
 
+import math
+import csv
 import numpy as np
+import pandas as pd
 
 from core import data_io, models, peaks, signals
+from core.residuals import build_residual, jacobian_fd
 from fit import orchestrator
+
+
+def _asymptotic_uncertainty(x, y_target, baseline, fitted, mode):
+    try:
+        theta = []
+        for p in fitted:
+            theta.extend([p.center, p.height, p.fwhm, p.eta])
+        theta = np.asarray(theta, float)
+        resid_fn = build_residual(x, y_target, fitted, mode, baseline, "linear", None)
+        J = jacobian_fd(resid_fn, theta)
+        r0 = resid_fn(theta)
+        rss = float(np.dot(r0, r0))
+        m = r0.size
+        jtj = J.T @ J
+        try:
+            cov = np.linalg.inv(jtj)
+        except np.linalg.LinAlgError:
+            cov = np.linalg.pinv(jtj)
+        dof = max(m - theta.size, 1)
+        sigma2 = rss / dof
+        cov *= sigma2
+        sigma = np.sqrt(np.diag(cov))
+
+        def ymodel(th):
+            tmp = []
+            for i in range(len(fitted)):
+                c, h, w, e = th[4 * i : 4 * i + 4]
+                tmp.append(peaks.Peak(c, h, w, e))
+            total = models.pv_sum(x, tmp)
+            if baseline is not None:
+                total = total + baseline
+            return total
+
+        y0 = ymodel(theta)
+        G = np.empty((x.size, theta.size), float)
+        for j in range(theta.size):
+            step = 1e-6 * max(1.0, abs(theta[j]))
+            tp = theta.copy()
+            tp[j] += step
+            G[:, j] = (ymodel(tp) - y0) / step
+        var = np.einsum('ij,jk,ik->i', G, cov, G)
+        band_std = np.sqrt(np.maximum(var, 0.0))
+        z = 1.96
+        lo = y0 - z * band_std
+        hi = y0 + z * band_std
+        return sigma, (x, lo, hi, y0), {"dof": dof, "s2": sigma2, "rmse": math.sqrt(rss / m)}
+    except Exception:
+        return np.full(4 * len(fitted), np.nan), None, {"dof": np.nan, "s2": np.nan, "rmse": np.nan}
 
 
 def _auto_seed(x: np.ndarray, y: np.ndarray, baseline: np.ndarray, max_peaks: int = 5) -> List[peaks.Peak]:
@@ -74,25 +126,60 @@ def run(patterns: Iterable[str], config: dict, progress=None, log=None) -> None:
     mode = config.get("mode", "add")
     base_cfg = config.get("baseline", {})
     save_traces = bool(config.get("save_traces", False))
-    peak_output = config.get("peak_output", "peaks.csv")
     source = config.get("source", "template")
     reheight = bool(config.get("reheight", False))
     auto_max = int(config.get("auto_max", 5))
 
+    out_dir = Path(config.get("output_dir", Path(config.get("peak_output", "peaks.csv")).parent))
+    out_dir.mkdir(parents=True, exist_ok=True)
+    base_name = config.get("output_base")
+    if base_name is None:
+        peak_output_cfg = config.get("peak_output", out_dir / "batch_fit.csv")
+        base_name = Path(peak_output_cfg).stem.replace("_fit", "")
+    peak_output = out_dir / f"{base_name}_fit.csv"
+    unc_output = out_dir / f"{base_name}_uncertainty.csv"
+
     records = []
+    unc_rows = []
     ok = 0
 
     for i, path in enumerate(files, 1):
         if progress:
             progress(i, total, path)
         x, y = data_io.load_xy(path)
-        baseline = signals.als_baseline(
-            y,
-            lam=base_cfg.get("lam", 1e5),
-            p=base_cfg.get("p", 0.001),
-            niter=base_cfg.get("niter", 10),
-            tol=base_cfg.get("thresh", 0.0),
-        )
+        use_slice = bool(config.get("baseline_uses_fit_range", True))
+        xmin = config.get("fit_xmin")
+        xmax = config.get("fit_xmax")
+        if use_slice and xmin is not None and xmax is not None:
+            lo, hi = sorted((float(xmin), float(xmax)))
+            mask = (x >= lo) & (x <= hi)
+            if np.any(mask):
+                x_sub = x[mask]
+                y_sub = y[mask]
+                z_sub = signals.als_baseline(
+                    y_sub,
+                    lam=base_cfg.get("lam", 1e5),
+                    p=base_cfg.get("p", 0.001),
+                    niter=base_cfg.get("niter", 10),
+                    tol=base_cfg.get("thresh", 0.0),
+                )
+                baseline = np.interp(x, x_sub, z_sub, left=z_sub[0], right=z_sub[-1])
+            else:
+                baseline = signals.als_baseline(
+                    y,
+                    lam=base_cfg.get("lam", 1e5),
+                    p=base_cfg.get("p", 0.001),
+                    niter=base_cfg.get("niter", 10),
+                    tol=base_cfg.get("thresh", 0.0),
+                )
+        else:
+            baseline = signals.als_baseline(
+                y,
+                lam=base_cfg.get("lam", 1e5),
+                p=base_cfg.get("p", 0.001),
+                niter=base_cfg.get("niter", 10),
+                tol=base_cfg.get("thresh", 0.0),
+            )
 
         if source == "auto":
             template = _auto_seed(x, y, baseline, max_peaks=auto_max)
@@ -123,6 +210,22 @@ def run(patterns: Iterable[str], config: dict, progress=None, log=None) -> None:
         rmse = float(np.sqrt(np.mean(resid**2)))
         areas = [models.pv_area(p.height, p.fwhm, p.eta) for p in fitted]
         total = sum(areas) or 1.0
+        perf_extras = {
+            "perf_numba": bool(config.get("perf_numba", False)),
+            "perf_gpu": bool(config.get("perf_gpu", False)),
+            "perf_cache_baseline": bool(config.get("perf_cache_baseline", True)),
+            "perf_seed_all": bool(config.get("perf_seed_all", False)),
+            "perf_max_workers": int(config.get("perf_max_workers", 0)),
+        }
+        center_bounds = (
+            (float(x[0]), float(x[-1]))
+            if (opts.get("centers_in_window") or opts.get("bound_centers_to_window"))
+            else (np.nan, np.nan)
+        )
+        med_dx = float(np.median(np.diff(np.sort(x)))) if x.size > 1 else 0.0
+        fwhm_lo = opts.get("min_fwhm", max(1e-6, 2.0 * med_dx))
+        fit_lo = float(config.get("fit_xmin", x[0]))
+        fit_hi = float(config.get("fit_xmax", x[-1]))
         for idx, (p, area) in enumerate(zip(fitted, areas), start=1):
             records.append(
                 {
@@ -141,19 +244,87 @@ def run(patterns: Iterable[str], config: dict, progress=None, log=None) -> None:
                     "mode": mode,
                     "als_lam": base_cfg.get("lam"),
                     "als_p": base_cfg.get("p"),
-                    "fit_xmin": float(x[0]),
-                    "fit_xmax": float(x[-1]),
+                    "fit_xmin": fit_lo,
+                    "fit_xmax": fit_hi,
+                    "solver_choice": solver_name,
+                    "solver_loss": opts.get("loss", np.nan),
+                    "solver_weight": opts.get("weights", np.nan),
+                    "solver_fscale": opts.get("f_scale", np.nan),
+                    "solver_maxfev": opts.get("maxfev", np.nan),
+                    "solver_restarts": opts.get("restarts", np.nan),
+                    "solver_jitter_pct": opts.get("jitter_pct", np.nan),
+                    "use_baseline": True,
+                    "baseline_mode": mode,
+                    "baseline_uses_fit_range": bool(config.get("baseline_uses_fit_range", True)),
+                    "als_niter": base_cfg.get("niter"),
+                    "als_thresh": base_cfg.get("thresh"),
+                    **perf_extras,
+                    "bounds_center_lo": center_bounds[0],
+                    "bounds_center_hi": center_bounds[1],
+                    "bounds_fwhm_lo": fwhm_lo,
+                    "bounds_height_lo": 0.0,
+                    "bounds_height_hi": np.nan,
+                    "x_scale": opts.get("x_scale", np.nan),
                 }
             )
 
+        if res.success:
+            y_target = y if mode == "add" else y - baseline
+            base_resid = baseline if mode == "add" else None
+            sigma, _band, info = _asymptotic_uncertainty(x, y_target, base_resid, fitted, mode)
+        else:
+            sigma = np.full(4 * len(fitted), np.nan)
+            info = {"dof": np.nan, "rmse": rmse}
+        z = 1.96
+        for idx, p in enumerate(fitted, start=1):
+            sc = sigma[4 * (idx - 1)] if sigma.size >= 4 * idx else np.nan
+            sh = sigma[4 * (idx - 1) + 1] if sigma.size >= 4 * idx + 1 else np.nan
+            sf = sigma[4 * (idx - 1) + 2] if sigma.size >= 4 * idx + 2 else np.nan
+            se = sigma[4 * (idx - 1) + 3] if sigma.size >= 4 * idx + 3 else np.nan
+            if p.lock_center:
+                sc = np.nan
+            if p.lock_width:
+                sf = np.nan
+            params = [
+                ("center", p.center, sc, not p.lock_center),
+                ("height", p.height, sh, True),
+                ("fwhm", p.fwhm, sf, not p.lock_width),
+                ("eta", p.eta, se, True),
+            ]
+            for pname, val, std, free in params:
+                if free and np.isfinite(std):
+                    ci_lo, ci_hi = val - z * std, val + z * std
+                else:
+                    ci_lo = ci_hi = np.nan
+                unc_rows.append(
+                    {
+                        "file": Path(path).name,
+                        "peak": idx,
+                        "param": pname,
+                        "value": val,
+                        "stderr": std if np.isfinite(std) else np.nan,
+                        "ci_lo": ci_lo,
+                        "ci_hi": ci_hi,
+                        "method": "asymptotic",
+                        "rmse": rmse,
+                        "dof": info.get("dof", np.nan),
+                    }
+                )
+
         trace_path = None
         if save_traces:
-            trace_csv = data_io.build_trace_table(
-                x, y, baseline, fitted, mode=mode
-            )
-            trace_path = Path(path).with_suffix(Path(path).suffix + ".trace.csv")
-            with trace_path.open("w", encoding="utf-8") as fh:
+            trace_csv = data_io.build_trace_table(x, y, baseline, fitted)
+            trace_path = out_dir / f"{Path(path).stem}_trace.csv"
+            with trace_path.open("w", encoding="utf-8", newline="") as fh:
                 fh.write(trace_csv)
+        if _band is not None:
+            xb, lob, hib, yfit = _band
+            band_path = out_dir / f"{Path(path).stem}_uncertainty_band.csv"
+            with band_path.open("w", newline="", encoding="utf-8") as fh:
+                bw = csv.writer(fh, lineterminator="\n")
+                bw.writerow(["x", "y_fit", "y_lo95", "y_hi95"])
+                for xi, yi, lo, hi in zip(xb, yfit, lob, hib):
+                    bw.writerow([xi, yi, lo, hi])
         if log:
             msg = f"{Path(path).name}: {'ok' if res.success else 'fail'} rmse={rmse:.3g}"
             if trace_path:
@@ -163,7 +334,8 @@ def run(patterns: Iterable[str], config: dict, progress=None, log=None) -> None:
             ok += 1
 
     peak_csv = data_io.build_peak_table(records)
-    with open(peak_output, "w", encoding="utf-8") as fh:
+    with peak_output.open("w", encoding="utf-8", newline="") as fh:
         fh.write(peak_csv)
+    data_io.write_dataframe(pd.DataFrame(unc_rows), unc_output)
 
     return ok, total

--- a/tests/test_batch_baseline_range.py
+++ b/tests/test_batch_baseline_range.py
@@ -1,0 +1,50 @@
+import sys
+import pathlib
+import numpy as np
+import pandas as pd
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from batch import runner
+from core.peaks import Peak
+from core import signals
+from ui.app import pseudo_voigt  # noqa: E402
+
+
+def test_batch_baseline_range(tmp_path):
+    x = np.linspace(-5, 5, 101)
+    peak = Peak(0.0, 1.0, 1.0, 0.5)
+    baseline_true = 0.1 * x
+    y = baseline_true + pseudo_voigt(x, peak.height, peak.center, peak.fwhm, peak.eta)
+    data_file = tmp_path / "s.csv"
+    np.savetxt(data_file, np.column_stack([x, y]), delimiter=",")
+
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    cfg = {
+        "peaks": [peak.__dict__],
+        "solver": "classic",
+        "mode": "add",
+        "baseline": {"lam": 1e5, "p": 0.001, "niter": 10, "thresh": 0.0},
+        "save_traces": True,
+        "source": "template",
+        "reheight": False,
+        "auto_max": 5,
+        "classic": {},
+        "baseline_uses_fit_range": True,
+        "fit_xmin": -1.0,
+        "fit_xmax": 1.0,
+        "perf_numba": False,
+        "perf_gpu": False,
+        "perf_cache_baseline": True,
+        "perf_seed_all": False,
+        "perf_max_workers": 0,
+        "output_dir": str(out_dir),
+        "output_base": "batch",
+    }
+    runner.run([str(data_file)], cfg)
+    trace_df = pd.read_csv(out_dir / "s_trace.csv")
+    baseline_col = trace_df["baseline"].to_numpy()
+    mask = (x >= -1.0) & (x <= 1.0)
+    z_sub = signals.als_baseline(y[mask], lam=1e5, p=0.001, niter=10, tol=0.0)
+    expected = np.interp(x, x[mask], z_sub, left=z_sub[0], right=z_sub[-1])
+    assert np.allclose(baseline_col, expected)

--- a/tests/test_batch_output_dir.py
+++ b/tests/test_batch_output_dir.py
@@ -1,0 +1,54 @@
+import sys
+import pathlib
+import numpy as np
+import pandas as pd
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from batch import runner
+from core.peaks import Peak
+from ui.app import pseudo_voigt  # noqa: E402
+
+
+def test_batch_output_dir(tmp_path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    x = np.linspace(-5, 5, 101)
+    peak = Peak(0.0, 1.0, 1.0, 0.5)
+    y = pseudo_voigt(x, peak.height, peak.center, peak.fwhm, peak.eta)
+    for i in range(2):
+        arr = np.column_stack([x, y])
+        np.savetxt(data_dir / f"s{i}.csv", arr, delimiter=",")
+
+    cfg = {
+        "peaks": [peak.__dict__],
+        "solver": "classic",
+        "mode": "add",
+        "baseline": {"lam": 1e5, "p": 0.001, "niter": 10, "thresh": 0.0},
+        "save_traces": True,
+        "source": "template",
+        "reheight": False,
+        "auto_max": 5,
+        "classic": {},
+        "baseline_uses_fit_range": True,
+        "perf_numba": False,
+        "perf_gpu": False,
+        "perf_cache_baseline": True,
+        "perf_seed_all": False,
+        "perf_max_workers": 0,
+        "output_dir": str(out_dir),
+        "output_base": "batch",
+    }
+
+    runner.run([str(data_dir / "*.csv")], cfg)
+
+    assert (out_dir / "batch_fit.csv").exists()
+    assert (out_dir / "batch_uncertainty.csv").exists()
+    # traces and bands should also reside in out_dir
+    for stem in ["s0", "s1"]:
+        assert (out_dir / f"{stem}_trace.csv").exists()
+        assert (out_dir / f"{stem}_uncertainty_band.csv").exists()
+    # input directory should remain clean
+    for f in data_dir.iterdir():
+        assert f.suffix == ".csv" and "trace" not in f.name

--- a/tests/test_batch_smoke.py
+++ b/tests/test_batch_smoke.py
@@ -18,13 +18,13 @@ def test_batch_smoke():
             data = np.column_stack([xs, ys])
             np.savetxt(os.path.join(td, f"s{i}.csv"), data, delimiter=",", header="x,y", comments="")
 
-        out_csv = os.path.join(td, "out.csv")
         cfg = {
             "peaks": [{"center": 20, "height": 5, "fwhm": 5, "eta": 0.5}],
             "solver": "classic",
             "mode": "add",
             "baseline": {"lam": 1e5, "p": 0.001},
-            "peak_output": out_csv,
+            "output_dir": td,
+            "output_base": "out",
         }
         runner.run([os.path.join(td, "*.csv")], cfg)
-        assert os.path.exists(out_csv)
+        assert os.path.exists(os.path.join(td, "out_fit.csv"))

--- a/tests/test_batch_uncertainty_summary.py
+++ b/tests/test_batch_uncertainty_summary.py
@@ -1,0 +1,69 @@
+import sys
+import pathlib
+import numpy as np
+import pandas as pd
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from batch import runner
+from core.peaks import Peak
+from ui.app import pseudo_voigt  # noqa: E402
+
+
+def test_batch_uncertainty_summary(tmp_path):
+    x = np.linspace(-5, 5, 101)
+    peak = Peak(0.0, 1.0, 1.0, 0.5)
+    y = pseudo_voigt(x, peak.height, peak.center, peak.fwhm, peak.eta)
+    for i in range(2):
+        arr = np.column_stack([x, y])
+        np.savetxt(tmp_path / f"s{i}.csv", arr, delimiter=",")
+
+    cfg = {
+        "peaks": [peak.__dict__],
+        "solver": "classic",
+        "mode": "add",
+        "baseline": {"lam": 1e5, "p": 0.001, "niter": 10, "thresh": 0.0},
+        "save_traces": False,
+        "peak_output": str(tmp_path / "batch_fit.csv"),
+        "unc_output": str(tmp_path / "batch_uncertainty.csv"),
+        "source": "template",
+        "reheight": False,
+        "auto_max": 5,
+        "classic": {},
+        "baseline_uses_fit_range": True,
+        "perf_numba": False,
+        "perf_gpu": False,
+        "perf_cache_baseline": True,
+        "perf_seed_all": False,
+        "perf_max_workers": 0,
+    }
+
+    runner.run([str(tmp_path / "*.csv")], cfg)
+
+    fit_df = pd.read_csv(tmp_path / "batch_fit.csv")
+    for col in [
+        "solver_choice",
+        "solver_loss",
+        "solver_weight",
+        "solver_fscale",
+        "solver_maxfev",
+        "solver_restarts",
+        "solver_jitter_pct",
+        "baseline_uses_fit_range",
+        "perf_numba",
+    ]:
+        assert col in fit_df.columns
+
+    unc_df = pd.read_csv(tmp_path / "batch_uncertainty.csv")
+    assert set(unc_df.columns) == {
+        "file",
+        "peak",
+        "param",
+        "value",
+        "stderr",
+        "ci_lo",
+        "ci_hi",
+        "method",
+        "rmse",
+        "dof",
+    }
+    assert len(unc_df) == 2 * 1 * 4

--- a/tests/test_config_persistence_perf_unc.py
+++ b/tests/test_config_persistence_perf_unc.py
@@ -1,0 +1,47 @@
+import os
+import sys
+import pathlib
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from ui import app as app_module  # noqa: E402
+
+headless = (os.environ.get("DISPLAY", "") == "" and os.name != "nt")
+if headless:
+    pytest.skip("Skipping GUI tests in headless environment", allow_module_level=True)
+
+tk = pytest.importorskip("tkinter")
+
+
+def test_config_persistence_perf_unc(tmp_path, monkeypatch):
+    cfg_path = tmp_path / "cfg.json"
+    monkeypatch.setattr(app_module, "CONFIG_PATH", cfg_path)
+
+    root = tk.Tk(); root.withdraw()
+    app = app_module.PeakFitApp(root)
+    app.perf_numba.set(True)
+    app.perf_gpu.set(True)
+    app.perf_cache_baseline.set(False)
+    app.perf_seed_all.set(True)
+    app.perf_max_workers.set(5)
+    app.show_ci_band_var.set(False)
+    app.toggle_components()
+    app.show_legend_var.set(False)
+    app._on_legend_toggle()
+    root.destroy()
+
+    root2 = tk.Tk(); root2.withdraw()
+    app2 = app_module.PeakFitApp(root2)
+    cfg = app_module.load_config()
+    assert cfg["perf_numba"] is True
+    assert cfg["perf_gpu"] is True
+    assert cfg["perf_cache_baseline"] is False
+    assert cfg["perf_seed_all"] is True
+    assert cfg["perf_max_workers"] == 5
+    assert cfg["ui_show_uncertainty_band"] is False
+    assert cfg["ui_show_components"] is False
+    assert cfg["ui_show_legend"] is False
+    assert app2.show_ci_band_var.get() is False
+    assert app2.components_visible is False
+    assert app2.show_legend_var.get() is False
+    root2.destroy()

--- a/tests/test_export_no_blank_lines.py
+++ b/tests/test_export_no_blank_lines.py
@@ -1,0 +1,14 @@
+import sys, pathlib
+import pandas as pd
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from core import data_io  # noqa: E402
+
+
+def test_export_no_blank_lines(tmp_path):
+    df = pd.DataFrame({"a": [1, 2]})
+    path = tmp_path / "out.csv"
+    data_io.write_dataframe(df, path)
+    text = path.read_text()
+    assert "\n\n" not in text
+    assert text.endswith("\n")

--- a/tests/test_templates_auto_apply.py
+++ b/tests/test_templates_auto_apply.py
@@ -1,0 +1,62 @@
+import os
+import sys
+import pathlib
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from ui import app as app_module  # noqa: E402
+from batch import runner  # noqa: E402
+from ui.app import Peak, pseudo_voigt  # noqa: E402
+
+headless = (os.environ.get("DISPLAY", "") == "" and os.name != "nt")
+if headless:
+    pytest.skip("Skipping GUI tests in headless environment", allow_module_level=True)
+
+
+def test_templates_auto_apply(tmp_path, monkeypatch):
+    tk = pytest.importorskip("tkinter")
+    peak = Peak(0.0, 1.0, 1.0, 0.5)
+    cfg = {
+        "templates": {"t1": [peak.__dict__]},
+        "auto_apply_template": True,
+        "auto_apply_template_name": "t1",
+    }
+    root = tk.Tk(); root.withdraw()
+    app = app_module.PeakFitApp(root, cfg=cfg)
+    x = np.linspace(-5, 5, 101)
+    y = pseudo_voigt(x, peak.height, peak.center, peak.fwhm, peak.eta)
+    data_file = tmp_path / "single.csv"
+    np.savetxt(data_file, np.column_stack([x, y]), delimiter=",")
+    monkeypatch.setattr(app_module.filedialog, "askopenfilename", lambda **kw: str(data_file))
+    app.on_open()
+    assert len(app.peaks) == 1
+    assert app.peaks[0].center == pytest.approx(0.0)
+    root.destroy()
+
+    # Batch: template applied to each file
+    for i in range(2):
+        np.savetxt(tmp_path / f"b{i}.csv", np.column_stack([x, y]), delimiter=",")
+    cfg_batch = {
+        "peaks": [peak.__dict__],
+        "solver": "classic",
+        "mode": "add",
+        "baseline": {"lam": 1e5, "p": 0.001, "niter": 10, "thresh": 0.0},
+        "save_traces": False,
+        "source": "template",
+        "reheight": False,
+        "auto_max": 5,
+        "classic": {},
+        "baseline_uses_fit_range": True,
+        "perf_numba": False,
+        "perf_gpu": False,
+        "perf_cache_baseline": True,
+        "perf_seed_all": False,
+        "perf_max_workers": 0,
+        "output_dir": str(tmp_path),
+        "output_base": "batch",
+    }
+    runner.run([str(tmp_path / "b*.csv")], cfg_batch)
+    fit_df = pd.read_csv(tmp_path / "batch_fit.csv")
+    assert len(fit_df) == 2

--- a/tests/test_trace_schema_v27.py
+++ b/tests/test_trace_schema_v27.py
@@ -1,0 +1,30 @@
+import sys
+import pathlib
+import numpy as np
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from core import data_io
+from core.peaks import Peak
+from ui.app import pseudo_voigt  # noqa: E402
+
+
+def _headers(n):
+    x = np.linspace(-1, 1, 5)
+    y = np.zeros_like(x)
+    peaks = []
+    for i in range(n):
+        p = Peak(float(i), 1.0, 1.0, 0.5)
+        y += pseudo_voigt(x, 1.0, p.center, p.fwhm, p.eta)
+        peaks.append(p)
+    table = data_io.build_trace_table(x, y, np.zeros_like(x), peaks)
+    return table.splitlines()[0].split(',')
+
+
+def test_trace_schema_v27():
+    for n in (0, 1, 2):
+        hdr = _headers(n)
+        expect = ["x", "y_raw", "baseline", "y_target_add", "y_fit_add"]
+        expect += [f"peak{i+1}" for i in range(n)]
+        expect += ["y_target_sub", "y_fit_sub"]
+        expect += [f"peak{i+1}_sub" for i in range(n)]
+        assert hdr == expect

--- a/tests/test_uncertainty_csv_single.py
+++ b/tests/test_uncertainty_csv_single.py
@@ -1,0 +1,55 @@
+import os
+import sys
+import pathlib
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from ui.app import PeakFitApp, Peak, pseudo_voigt
+from core import data_io
+
+headless = (os.environ.get("DISPLAY", "") == "" and os.name != "nt")
+if headless:
+    pytest.skip("Skipping GUI tests in headless environment", allow_module_level=True)
+
+
+def test_uncertainty_csv_single(tmp_path):
+    tk = pytest.importorskip("tkinter")
+    root = tk.Tk()
+    root.withdraw()
+    app = PeakFitApp(root)
+    x = np.linspace(-5, 5, 101)
+    peak = Peak(0.0, 1.0, 1.0, 0.5)
+    y = pseudo_voigt(x, peak.height, peak.center, peak.fwhm, peak.eta)
+    app.x = x
+    app.y_raw = y
+    app.peaks = [peak]
+    app.use_baseline.set(False)
+    app.fit_xmin = x[0]
+    app.fit_xmax = x[-1]
+    app._run_asymptotic_uncertainty()
+    paths = data_io.derive_export_paths(str(tmp_path / "single.csv"))
+    app._maybe_export_uncertainty(
+        pathlib.Path(paths["unc_txt"]),
+        pathlib.Path(paths["unc_csv"]),
+        pathlib.Path(paths["unc_band"]),
+        0.0,
+    )
+    assert pathlib.Path(paths["unc_txt"]).exists()
+    assert pathlib.Path(paths["unc_csv"]).exists()
+    df = pd.read_csv(paths["unc_csv"])
+    assert set(df.columns) == {
+        "file",
+        "peak",
+        "param",
+        "value",
+        "stderr",
+        "ci_lo",
+        "ci_hi",
+        "method",
+        "rmse",
+        "dof",
+    }
+    assert {"center", "height", "fwhm"}.issubset(set(df["param"]))
+    root.destroy()

--- a/ui/app.py
+++ b/ui/app.py
@@ -155,12 +155,12 @@ import json
 import math
 import re
 import time
+import csv
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional
 
 import numpy as np
-import pandas as pd
 
 import os
 import matplotlib
@@ -169,18 +169,22 @@ if os.environ.get("DISPLAY", "") == "" and os.name != "nt":
 else:
     matplotlib.use("TkAgg")
 import matplotlib.pyplot as plt
+import matplotlib.font_manager as fm
+from matplotlib.font_manager import FontProperties
 matplotlib.rcdefaults()
+matplotlib.rcParams["font.family"] = "Arial"
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
 from matplotlib.widgets import SpanSelector
 
 import tkinter as tk
 from tkinter import ttk, filedialog, messagebox, simpledialog, scrolledtext
+import tkinter.font as tkfont
 import threading
 import traceback
 
 from scipy.signal import find_peaks
 
-from core import signals
+from core import signals, data_io
 from core.residuals import build_residual, jacobian_fd
 from fit import orchestrator, classic, modern_vp, modern
 try:  # optional
@@ -209,6 +213,11 @@ SOLVER_LABELS = {
     "modern_trf": "Modern (Legacy TRF)",
     "lmfit_vp": "LMFIT (Variable Projection)",
 }
+
+STEP_ICON_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAATElEQVR4nM3TOQ4AIAwDQYL4/5ehoskh26HBVYS00zHGT9udaCaIBHlAhiqAhhAAIRYoIRUI0GoCdg8V"
+    "MP/AAiFkgTJEAAyztf7C8w5Q0w4YsEzvsQAAAABJRU5ErkJggg=="
+)
 SOLVER_LABELS_INV = {v: k for k, v in SOLVER_LABELS.items()}
 
 
@@ -268,6 +277,14 @@ DEFAULTS = {
     "x_label_auto_math": True,
     "ui_show_legend": True,
     "legend_center_sigfigs": 6,
+    # Uncertainty and performance defaults
+    "show_uncertainty_band": True,
+    "baseline_uses_fit_range": True,
+    "perf_numba": False,
+    "perf_gpu": False,
+    "perf_cache_baseline": True,
+    "perf_seed_all": False,
+    "perf_max_workers": 0,
 }
 
 LOG_MAX_LINES = 5000
@@ -482,11 +499,22 @@ def load_xy_any(path: str):
 
 # ---------- Main GUI ----------
 class PeakFitApp:
-    def __init__(self, root):
+    def __init__(self, root, cfg=None):
         self.root = root
+        self.cfg = cfg if cfg is not None else load_config()
+        self.cfg.setdefault("baseline_uses_fit_range", True)
+        self.cfg.setdefault("ui_show_uncertainty_band", True)
+        self.cfg.setdefault("perf_numba", False)
+        self.cfg.setdefault("perf_gpu", False)
+        self.cfg.setdefault("perf_cache_baseline", True)
+        self.cfg.setdefault("perf_seed_all", False)
+        self.cfg.setdefault("perf_max_workers", 0)
+        save_config(self.cfg)
         self.root.title("Interactive Peak Fit (pseudo-Voigt)")
 
         performance.set_logger(self.log_threadsafe)
+
+        self.default_font = tkfont.nametofont("TkDefaultFont")
 
         # Data
         self.x = None
@@ -497,10 +525,10 @@ class PeakFitApp:
         # Baseline mode: "add" (fit over baseline) or "subtract"
         self.baseline_mode = tk.StringVar(value="add")
         # Option: compute ALS baseline only from fit range
-        self.baseline_use_range = tk.BooleanVar(value=False)
+        self.baseline_use_range = tk.BooleanVar(value=bool(self.cfg.get("baseline_uses_fit_range", True)))
+        self.baseline_use_range.trace_add("write", self.on_baseline_use_range_toggle)
 
         # Config
-        self.cfg = load_config()
         self.als_lam = tk.DoubleVar(value=self.cfg["als_lam"])
         self.als_asym = tk.DoubleVar(value=self.cfg["als_asym"])
         self.als_niter = tk.IntVar(value=self.cfg["als_niter"])
@@ -533,7 +561,7 @@ class PeakFitApp:
         self.template_var = tk.StringVar(value=self.auto_apply_template_name.get())
 
         # Components visibility
-        self.components_visible = True
+        self.components_visible = bool(self.cfg.get("ui_show_components", True))
 
         # Matplotlib click binding
         self.cid = None
@@ -587,9 +615,11 @@ class PeakFitApp:
         self.lmfit_share_eta = tk.BooleanVar(value=False)
         self.snr_text = tk.StringVar(value="S/N: --")
 
-        self.show_ci_band = False
+        self.show_ci_band = bool(self.cfg.get("ui_show_uncertainty_band", True))
         self.ci_band = None
-        self.show_ci_band_var = tk.BooleanVar(value=False)
+        self.current_file: Optional[Path] = None
+        self.show_ci_band_var = tk.BooleanVar(value=self.show_ci_band)
+        self.show_ci_band_var.trace_add("write", self._toggle_ci_band)
 
         # Uncertainty and performance controls
         unc_cfg = self.cfg.get("unc_method", "asymptotic")
@@ -600,27 +630,72 @@ class PeakFitApp:
         else:
             unc_label = "Asymptotic"
         self.unc_method = tk.StringVar(value=unc_label)
-        self.perf_numba = tk.BooleanVar(value=False)
-        self.perf_gpu = tk.BooleanVar(value=False)
-        self.perf_cache = tk.BooleanVar(value=True)
-        self.perf_deterministic = tk.BooleanVar(value=False)
-        self.perf_parallel = tk.BooleanVar(value=False)
+        self.perf_numba = tk.BooleanVar(value=bool(self.cfg.get("perf_numba", False)))
+        self.perf_gpu = tk.BooleanVar(value=bool(self.cfg.get("perf_gpu", False)))
+        self.perf_cache_baseline = tk.BooleanVar(value=bool(self.cfg.get("perf_cache_baseline", True)))
+        self.perf_seed_all = tk.BooleanVar(value=bool(self.cfg.get("perf_seed_all", False)))
+        self.perf_max_workers = tk.IntVar(value=int(self.cfg.get("perf_max_workers", 0)))
+        self.perf_numba.trace_add("write", lambda *_: self.apply_performance())
+        self.perf_gpu.trace_add("write", lambda *_: self.apply_performance())
+        self.perf_cache_baseline.trace_add("write", lambda *_: self.apply_performance())
+        self.perf_seed_all.trace_add("write", lambda *_: self.apply_performance())
+        self.perf_max_workers.trace_add("write", lambda *_: self.apply_performance())
         self.seed_var = tk.StringVar(value="")
-        self.workers_var = tk.IntVar(value=0)
         self.gpu_chunk_var = tk.IntVar(value=262144)
 
         # UI
         self._build_ui()
         self._new_figure()
         self._update_template_info()
+        self.apply_performance()
 
     # ----- UI -----
     def _build_ui(self):
-        top = ttk.Frame(self.root, padding=6); top.pack(side=tk.TOP, fill=tk.X)
-        ttk.Button(top, text="Open Data…", command=self.on_open).pack(side=tk.LEFT)
-        ttk.Button(top, text="Export CSV…", command=self.on_export).pack(side=tk.LEFT, padx=(6,0))
-        ttk.Button(top, text="Help", command=self.show_help).pack(side=tk.LEFT, padx=(6,0))
-        self.file_label = ttk.Label(top, text="No file loaded"); self.file_label.pack(side=tk.LEFT, padx=10)
+        top = ttk.Frame(self.root, padding=6)
+        top.pack(side=tk.TOP, fill=tk.X)
+        top.columnconfigure(0, weight=1)
+
+        self.action_bar = ttk.Frame(top)
+        self.action_bar.grid(row=0, column=0, sticky="w")
+
+        self.file_label = ttk.Label(top, text="No file loaded")
+        self.file_label.grid(row=0, column=1, sticky="e")
+
+        file_seg = ttk.Frame(self.action_bar)
+        file_seg.pack(side=tk.LEFT)
+        ttk.Button(file_seg, text="Open", command=self.on_open).pack(side=tk.LEFT, padx=2)
+        ttk.Button(file_seg, text="Export", command=self.on_export).pack(side=tk.LEFT, padx=2)
+        ttk.Button(file_seg, text="Batch", command=self.run_batch).pack(side=tk.LEFT, padx=2)
+
+        ttk.Separator(self.action_bar, orient=tk.VERTICAL).pack(side=tk.LEFT, fill=tk.Y, padx=3)
+
+        fit_seg = ttk.Frame(self.action_bar)
+        fit_seg.pack(side=tk.LEFT)
+        try:
+            self.step_icon = tk.PhotoImage(data=STEP_ICON_B64)
+            self.step_btn = ttk.Button(fit_seg, image=self.step_icon, command=self.step_once)
+        except Exception:
+            self.step_btn = ttk.Button(fit_seg, text="Step", command=self.step_once)
+        self.step_btn.pack(side=tk.LEFT, padx=2)
+        ttk.Button(fit_seg, text="Fit", command=self.fit).pack(side=tk.LEFT, padx=2)
+
+        ttk.Separator(self.action_bar, orient=tk.VERTICAL).pack(side=tk.LEFT, fill=tk.Y, padx=3)
+
+        graph_seg = ttk.Frame(self.action_bar)
+        graph_seg.pack(side=tk.LEFT)
+        ttk.Button(
+            graph_seg,
+            text="Uncertainty",
+            command=lambda: self.show_ci_band_var.set(not self.show_ci_band_var.get()),
+        ).pack(side=tk.LEFT, padx=2)
+        ttk.Button(graph_seg, text="Legend", command=self._toggle_legend_action).pack(
+            side=tk.LEFT, padx=2
+        )
+        ttk.Button(graph_seg, text="Components", command=self.toggle_components).pack(
+            side=tk.LEFT, padx=2
+        )
+
+        self._update_file_label(None)
 
         mid = ttk.Panedwindow(self.root, orient=tk.HORIZONTAL)
         mid.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
@@ -681,8 +756,7 @@ class PeakFitApp:
         ttk.Radiobutton(mode_row, text="Add to fit", variable=self.baseline_mode, value="add", command=self.refresh_plot).pack(side=tk.LEFT)
         ttk.Radiobutton(mode_row, text="Subtract",  variable=self.baseline_mode, value="subtract", command=self.refresh_plot).pack(side=tk.LEFT, padx=4)
 
-        ttk.Checkbutton(baseline_box, text="Baseline uses fit range", variable=self.baseline_use_range,
-                        command=self.on_baseline_use_range_toggle).pack(anchor="w", pady=(2,0))
+        ttk.Checkbutton(baseline_box, text="Baseline uses fit range", variable=self.baseline_use_range).pack(anchor="w", pady=(2,0))
 
         row = ttk.Frame(baseline_box); row.pack(fill=tk.X, pady=2)
         ttk.Label(row, text="λ (smooth):").pack(side=tk.LEFT)
@@ -909,63 +983,37 @@ class PeakFitApp:
             unc_box,
             text="Show uncertainty band",
             variable=self.show_ci_band_var,
-            command=self._toggle_ci_band,
         ).pack(anchor="w", padx=4)
         self._update_unc_widgets()
 
-        # Axes / label controls (moved here)
+        # Axes / label controls
         axes_box = ttk.Labelframe(right, text="Axes / Labels")
         axes_box.pack(fill=tk.X, pady=6)
-
-        ttk.Label(axes_box, text="X-axis label:").pack(side=tk.LEFT)
-        self.x_label_entry = ttk.Entry(axes_box, width=16, textvariable=self.x_label_var)
+        row1 = ttk.Frame(axes_box); row1.pack(fill=tk.X)
+        ttk.Label(row1, text="X-axis label:").pack(side=tk.LEFT)
+        self.x_label_entry = ttk.Entry(row1, width=16, textvariable=self.x_label_var)
         self.x_label_entry.pack(side=tk.LEFT, padx=4)
-        ttk.Button(axes_box, text="Apply", command=self.apply_x_label).pack(side=tk.LEFT, padx=2)
-        ttk.Button(axes_box, text="Superscript", command=self.insert_superscript).pack(side=tk.LEFT, padx=2)
-        ttk.Button(axes_box, text="Subscript", command=self.insert_subscript).pack(side=tk.LEFT, padx=2)
-        ttk.Button(axes_box, text="Save as default", command=self.save_x_label_default).pack(side=tk.LEFT, padx=2)
-
-        row_fmt = ttk.Frame(axes_box); row_fmt.pack(fill=tk.X, pady=(2, 0))
-        ttk.Checkbutton(row_fmt, text="Auto-format superscripts/subscripts",
-                        variable=self.x_label_auto_math,
-                        command=self._on_x_label_auto_math_toggle).pack(side=tk.LEFT)
-
-        # Legend controls
-        row_leg = ttk.Frame(axes_box)
-        row_leg.pack(fill=tk.X, pady=(4, 0))
-        ttk.Checkbutton(
-            row_leg,
-            text="Show legend",
-            variable=self.show_legend_var,
-            command=self._on_legend_toggle,
-        ).pack(side=tk.LEFT)
-        ttk.Label(row_leg, text="Center sig figs:").pack(side=tk.LEFT, padx=(8, 2))
-        ttk.Spinbox(
-            row_leg,
-            from_=3,
-            to=10,
-            width=4,
-            textvariable=self.legend_center_sigfigs,
-            command=self._on_legend_sigfigs_change,
-        ).pack(side=tk.LEFT)
+        ttk.Button(row1, text="Apply", command=self.apply_x_label).pack(side=tk.LEFT, padx=2)
+        row2 = ttk.Frame(axes_box); row2.pack(fill=tk.X, pady=(2,0))
+        ttk.Button(row2, text="Superscript", command=self.insert_superscript).pack(side=tk.LEFT, padx=2)
+        ttk.Button(row2, text="Subscript", command=self.insert_subscript).pack(side=tk.LEFT, padx=2)
+        ttk.Checkbutton(row2, text="Auto-format", variable=self.x_label_auto_math,
+                        command=self._on_x_label_auto_math_toggle).pack(side=tk.LEFT, padx=2)
+        ttk.Button(row2, text="Save as default", command=self.save_x_label_default).pack(side=tk.LEFT, padx=2)
+        ttk.Checkbutton(row2, text="Show legend", variable=self.show_legend_var,
+                        command=self._on_legend_toggle).pack(side=tk.LEFT, padx=2)
 
         # Performance panel
         perf_box = ttk.Labelframe(right, text="Performance"); perf_box.pack(fill=tk.X, pady=4)
-        ttk.Checkbutton(perf_box, text="Numba", variable=self.perf_numba,
-                        command=self.apply_performance).pack(anchor="w")
-        ttk.Checkbutton(perf_box, text="GPU", variable=self.perf_gpu,
-                        command=self.apply_performance).pack(anchor="w")
-        ttk.Checkbutton(perf_box, text="Cache baseline", variable=self.perf_cache,
-                        command=self.apply_performance).pack(anchor="w")
-        ttk.Checkbutton(perf_box, text="Deterministic seeds", variable=self.perf_deterministic,
-                        command=self.apply_performance).pack(anchor="w")
-        ttk.Checkbutton(perf_box, text="Parallel bootstrap", variable=self.perf_parallel,
-                        command=self.apply_performance).pack(anchor="w")
+        ttk.Checkbutton(perf_box, text="Numba", variable=self.perf_numba).pack(anchor="w")
+        ttk.Checkbutton(perf_box, text="GPU", variable=self.perf_gpu).pack(anchor="w")
+        ttk.Checkbutton(perf_box, text="Cache baseline", variable=self.perf_cache_baseline).pack(anchor="w")
+        ttk.Checkbutton(perf_box, text="Seed all", variable=self.perf_seed_all).pack(anchor="w")
         rowp = ttk.Frame(perf_box); rowp.pack(fill=tk.X, pady=2)
         ttk.Label(rowp, text="Seed:").pack(side=tk.LEFT)
         ttk.Entry(rowp, width=8, textvariable=self.seed_var).pack(side=tk.LEFT, padx=4)
         ttk.Label(rowp, text="Max workers:").pack(side=tk.LEFT, padx=(8,0))
-        ttk.Spinbox(rowp, from_=0, to=64, textvariable=self.workers_var, width=5).pack(side=tk.LEFT)
+        ttk.Spinbox(rowp, from_=0, to=64, textvariable=self.perf_max_workers, width=5).pack(side=tk.LEFT)
         ttk.Label(rowp, text="GPU chunk:").pack(side=tk.LEFT, padx=(8,0))
         ttk.Entry(rowp, width=7, textvariable=self.gpu_chunk_var).pack(side=tk.LEFT, padx=2)
         ttk.Button(rowp, text="Apply", command=self.apply_performance).pack(side=tk.LEFT, padx=4)
@@ -986,15 +1034,6 @@ class PeakFitApp:
         ttk.Label(rowb3, text="Auto max:").pack(side=tk.LEFT, padx=(8,0))
         ttk.Spinbox(rowb3, from_=1, to=20, textvariable=self.batch_auto_max, width=5).pack(side=tk.LEFT)
         ttk.Button(batch_box, text="Run Batch…", command=self.run_batch).pack(side=tk.LEFT, pady=4)
-
-        # Actions
-        actions = ttk.Labelframe(right, text="Actions"); actions.pack(fill=tk.X, pady=4)
-        ttk.Button(actions, text="Auto-seed", command=self.auto_seed).pack(side=tk.LEFT)
-        self.step_btn = ttk.Button(actions, text="Step \u25B6", command=self.step_once)
-        self.step_btn.pack(side=tk.LEFT, padx=4)
-        ttk.Button(actions, text="Fit", command=self.fit).pack(side=tk.LEFT, padx=4)
-        ttk.Label(actions, textvariable=self.solver_title).pack(side=tk.LEFT, padx=4)
-        ttk.Button(actions, text="Toggle components", command=self.toggle_components).pack(side=tk.LEFT, padx=4)
 
         # Status bar and log
         bar = ttk.Frame(self.root); bar.pack(side=tk.BOTTOM, fill=tk.X)
@@ -1123,9 +1162,15 @@ class PeakFitApp:
         else:
             self._suspend_clicks()
 
-    def _toggle_ci_band(self):
+    def _toggle_ci_band(self, *_):
         self.show_ci_band = bool(self.show_ci_band_var.get())
+        self.cfg["ui_show_uncertainty_band"] = self.show_ci_band
+        save_config(self.cfg)
         self.refresh_plot()
+
+    def _toggle_legend_action(self):
+        self.show_legend_var.set(not self.show_legend_var.get())
+        self._on_legend_toggle()
 
     def _fd_jacobian(self, residual, p0):
         p0 = np.asarray(p0, float)
@@ -1179,6 +1224,9 @@ class PeakFitApp:
             ttk.Button(btns, text="Save log…", command=self._save_log).pack(side=tk.LEFT)
             btns.pack(fill=tk.X)
             self._log_console = scrolledtext.ScrolledText(self._log_frame, height=8, state="disabled")
+            self._log_console.configure(
+                bg="#000000", fg="#00ff66", insertbackground="#00ff66", font=self.default_font
+            )
             self._log_console.pack(fill=tk.BOTH, expand=True)
         self._log_console.configure(state="normal")
         self._log_console.delete("1.0", "end")
@@ -1300,7 +1348,23 @@ class PeakFitApp:
             if self.x is not None:
                 self.ax.set_xlim(float(self.x.min()), float(self.x.max()))
                 self.ax.relim(); self.ax.autoscale_view()
-                self.canvas.draw_idle()
+        self.canvas.draw_idle()
+
+    def _update_file_label(self, path: Optional[str]) -> None:
+        if path:
+            p = Path(path)
+            self.current_file = p
+            full = str(p)
+            disp = full if len(full) <= 60 else "..." + full[-57:]
+            self.file_label.config(text=disp)
+            self.file_label.unbind("<Enter>")
+            self.file_label.unbind("<Leave>")
+            add_tooltip(self.file_label, full)
+        else:
+            self.current_file = None
+            self.file_label.config(text="No file loaded")
+            self.file_label.unbind("<Enter>")
+            self.file_label.unbind("<Leave>")
 
     # ----- File handling -----
     def on_open(self):
@@ -1322,7 +1386,7 @@ class PeakFitApp:
             return
 
         self.x, self.y_raw = x, y
-        self.file_label.config(text=Path(path).name)
+        self._update_file_label(path)
         self.compute_baseline()
         self.peaks.clear()
 
@@ -1339,7 +1403,9 @@ class PeakFitApp:
         self.status_var.set("Loaded. Adjust baseline, (optionally) set fit range, add peaks; Fit.")
 
     # ----- Baseline -----
-    def on_baseline_use_range_toggle(self):
+    def on_baseline_use_range_toggle(self, *_):
+        self.cfg["baseline_uses_fit_range"] = bool(self.baseline_use_range.get())
+        save_config(self.cfg)
         if self.y_raw is None:
             return
         self.compute_baseline()
@@ -2003,12 +2069,11 @@ class PeakFitApp:
                 return
             self.peaks[:] = res.peaks_out
             self.refresh_tree(keep_selection=True)
-            if self.show_ci_band:
+            try:
                 self._run_asymptotic_uncertainty()
-            else:
-                self.ci_band = None
-                self.show_ci_band = False
-                self.show_ci_band_var.set(False)
+            except Exception as e:
+                self.log(f"Uncertainty failed: {e}", level="WARN")
+            self.show_ci_band = bool(self.show_ci_band_var.get())
             self.refresh_plot()
             self.set_busy(False, f"Fit done. RMSE {res.rmse:.4g}")
             npts = int(np.count_nonzero(mask))
@@ -2032,6 +2097,12 @@ class PeakFitApp:
         )
         if not out_csv:
             return
+        p = Path(out_csv)
+        base = p.with_suffix("")
+        output_dir = base.parent
+        output_base = base.name
+        fit_path = output_dir / f"{output_base}_fit.csv"
+        unc_path = output_dir / f"{output_base}_uncertainty.csv"
         patterns = [p.strip() for p in self.batch_patterns.get().split(";") if p.strip()]
         if not patterns:
             patterns = ["*.csv", "*.txt", "*.dat"]
@@ -2060,12 +2131,23 @@ class PeakFitApp:
                 "thresh": float(self.als_thresh.get()),
             },
             "save_traces": bool(self.batch_save_traces.get()),
-            "peak_output": out_csv,
             "source": source,
             "reheight": bool(self.batch_reheight.get()),
             "auto_max": int(self.batch_auto_max.get()),
             solver: self._solver_options(solver),
+            "baseline_uses_fit_range": bool(self.baseline_use_range.get()),
+            "perf_numba": bool(self.perf_numba.get()),
+            "perf_gpu": bool(self.perf_gpu.get()),
+            "perf_cache_baseline": bool(self.perf_cache_baseline.get()),
+            "perf_seed_all": bool(self.perf_seed_all.get()),
+            "perf_max_workers": int(self.perf_max_workers.get()),
+            "output_dir": str(output_dir),
+            "output_base": output_base,
         }
+
+        if self.fit_xmin is not None and self.fit_xmax is not None:
+            cfg["fit_xmin"] = float(self.fit_xmin)
+            cfg["fit_xmax"] = float(self.fit_xmax)
 
         self.cfg["batch_patterns"] = self.batch_patterns.get()
         self.cfg["batch_source"] = source
@@ -2090,7 +2172,7 @@ class PeakFitApp:
             ok, total = res
             self.set_busy(False, f"Batch done. {ok}/{total} succeeded.")
             self.log(f"Batch done: {ok}/{total} succeeded.")
-            messagebox.showinfo("Batch", f"Summary saved:\n{out_csv}")
+            messagebox.showinfo("Batch", f"Summary saved:\n{fit_path}")
 
         self.set_busy(True, "Batch running…")
         self.run_in_thread(work, done)
@@ -2152,21 +2234,25 @@ class PeakFitApp:
             lo = np.nan_to_num(lo)
             hi = np.nan_to_num(hi)
             warn_nonfinite = True
-        self.ci_band = (x_all, lo, hi)
+        self.ci_band = (x_all, lo, hi, y0)
+        self.show_ci_band = True
 
         bw = (hi - lo)[mask]
         bw_stats = (float(np.min(bw)), float(np.median(bw)), float(np.max(bw)))
 
+        dof = max(m - rank, 1)
         info = {
             "m": m,
             "n": theta.size,
             "rank": rank,
-            "dof": m - rank,
+            "dof": dof,
             "cond": cond,
             "rmse": math.sqrt(rss / m),
+            "s2": rss / dof,
             "bw": bw_stats,
             "warn_nonfinite": warn_nonfinite,
         }
+        self.unc_info = info
         return cov, theta, info
 
     def _format_asymptotic_summary(self, cov, theta, info, band):
@@ -2282,32 +2368,148 @@ class PeakFitApp:
     def apply_performance(self):
         performance.set_numba(bool(self.perf_numba.get()))
         performance.set_gpu(bool(self.perf_gpu.get()))
-        performance.set_cache_baseline(bool(self.perf_cache.get()))
+        performance.set_cache_baseline(bool(self.perf_cache_baseline.get()))
         seed_txt = self.seed_var.get().strip()
         seed = int(seed_txt) if seed_txt else None
-        if self.perf_deterministic.get():
+        if self.perf_seed_all.get():
             performance.set_seed(seed)
         else:
             performance.set_seed(None)
-        if self.perf_parallel.get():
-            performance.set_max_workers(self.workers_var.get())
-        else:
-            performance.set_max_workers(0)
+        performance.set_max_workers(int(self.perf_max_workers.get()))
         performance.set_gpu_chunk(self.gpu_chunk_var.get())
+        self.cfg["perf_numba"] = bool(self.perf_numba.get())
+        self.cfg["perf_gpu"] = bool(self.perf_gpu.get())
+        self.cfg["perf_cache_baseline"] = bool(self.perf_cache_baseline.get())
+        self.cfg["perf_seed_all"] = bool(self.perf_seed_all.get())
+        self.cfg["perf_max_workers"] = int(self.perf_max_workers.get())
+        save_config(self.cfg)
         self.log(f"Backend: {performance.which_backend()} | workers={performance.get_max_workers()}")
         self.status_var.set("Performance options applied.")
+
+    def _maybe_export_uncertainty(
+        self, txt_path: Path, csv_path: Path, band_path: Path, rmse: float
+    ) -> None:
+        try:
+            if self.ci_band is None or getattr(self, "param_sigma", None) is None:
+                try:
+                    self._run_asymptotic_uncertainty()
+                except Exception as e:
+                    self.log(f"Uncertainty failed: {e}", level="WARN")
+
+            opts = self._solver_options()
+            solver = self.solver_choice.get()
+            fname_disp = self.current_file.name if self.current_file else "(unsaved)"
+            lines = [f"File: {fname_disp}", "Uncertainty method: Asymptotic (95% CI, z=1.96)"]
+            lines.append(
+                "Solver: "
+                f"{solver}, loss={opts.get('loss', '')}, weight={opts.get('weights', '')}, "
+                f"f_scale={opts.get('f_scale', '')}, maxfev={opts.get('maxfev', '')}, "
+                f"restarts={opts.get('restarts', '')}, jitter_pct={opts.get('jitter_pct', '')}"
+            )
+            lines.append(
+                "Baseline: "
+                f"uses_fit_range={bool(self.baseline_use_range.get())}, "
+                f"lam={self.als_lam.get()}, p={self.als_asym.get()}, "
+                f"niter={self.als_niter.get()}, thresh={self.als_thresh.get()}"
+            )
+            lines.append(
+                "Performance: "
+                f"numba={bool(self.perf_numba.get())}, gpu={bool(self.perf_gpu.get())}, "
+                f"cache_baseline={bool(self.perf_cache_baseline.get())}, "
+                f"seed_all={bool(self.perf_seed_all.get())}, max_workers={int(self.perf_max_workers.get())}"
+            )
+            lines.append("Peaks:")
+            z = 1.96
+            sigma = getattr(self, "param_sigma", np.array([]))
+            dof = getattr(self, "unc_info", {}).get("dof", np.nan)
+            rows = []
+            fname = self.current_file.name if self.current_file else ""
+            for i, p in enumerate(self.peaks, 1):
+                sc = sigma[4 * (i - 1)] if sigma.size >= 4 * i else np.nan
+                sh = sigma[4 * (i - 1) + 1] if sigma.size >= 4 * i + 1 else np.nan
+                sf = sigma[4 * (i - 1) + 2] if sigma.size >= 4 * i + 2 else np.nan
+                se = sigma[4 * (i - 1) + 3] if sigma.size >= 4 * i + 3 else np.nan
+                c_lo = p.center - z * sc if np.isfinite(sc) and not p.lock_center else np.nan
+                c_hi = p.center + z * sc if np.isfinite(sc) and not p.lock_center else np.nan
+                h_lo = p.height - z * sh if np.isfinite(sh) else np.nan
+                h_hi = p.height + z * sh if np.isfinite(sh) else np.nan
+                f_lo = p.fwhm - z * sf if np.isfinite(sf) and not p.lock_width else np.nan
+                f_hi = p.fwhm + z * sf if np.isfinite(sf) and not p.lock_width else np.nan
+                lines.append(
+                    f"  #{i} center={p.center:.5g}, 95% CI [{c_lo:.5g}, {c_hi:.5g}]; "
+                    f"height={p.height:.5g}, 95% CI [{h_lo:.5g}, {h_hi:.5g}]; "
+                    f"fwhm={p.fwhm:.5g}, 95% CI [{f_lo:.5g}, {f_hi:.5g}]; "
+                    f"eta={p.eta:.5g}(fixed)"
+                )
+                params = [
+                    ("center", p.center, sc, not p.lock_center),
+                    ("height", p.height, sh, True),
+                    ("fwhm", p.fwhm, sf, not p.lock_width),
+                    ("eta", p.eta, se, True),
+                ]
+                for pname, val, std, free in params:
+                    ci_lo = val - z * std if free and np.isfinite(std) else np.nan
+                    ci_hi = val + z * std if free and np.isfinite(std) else np.nan
+                    rows.append(
+                        {
+                            "file": fname,
+                            "peak": i,
+                            "param": pname,
+                            "value": val,
+                            "stderr": std if np.isfinite(std) else np.nan,
+                            "ci_lo": ci_lo,
+                            "ci_hi": ci_hi,
+                            "method": "asymptotic",
+                            "rmse": rmse,
+                            "dof": dof,
+                        }
+                    )
+
+            lines.append(f"Fit quality: RMSE={rmse:.5g}, DOF={dof}")
+            with txt_path.open("w", encoding="utf-8", newline="") as fh:
+                fh.write("\n".join(lines) + "\n")
+
+            header = [
+                "file",
+                "peak",
+                "param",
+                "value",
+                "stderr",
+                "ci_lo",
+                "ci_hi",
+                "method",
+                "rmse",
+                "dof",
+            ]
+            with csv_path.open("w", newline="", encoding="utf-8") as fh:
+                writer = csv.DictWriter(fh, fieldnames=header, lineterminator="\n")
+                writer.writeheader()
+                for row in rows:
+                    writer.writerow(row)
+
+            if self.ci_band is not None:
+                xb, lob, hib, yfit = self.ci_band
+                with band_path.open("w", newline="", encoding="utf-8") as fh:
+                    bw = csv.writer(fh, lineterminator="\n")
+                    bw.writerow(["x", "y_fit", "y_lo95", "y_hi95"])
+                    for xi, yi, lo, hi in zip(xb, yfit, lob, hib):
+                        bw.writerow([xi, yi, lo, hi])
+        except Exception as e:  # pragma: no cover - defensive
+            self.log(f"Uncertainty export failed: {e}", level="WARN")
+            self.status_var.set("Uncertainty export failed.")
 
     def on_export(self):
         if self.x is None or self.y_raw is None or not self.peaks:
             messagebox.showinfo("Export", "Load data and perform a fit first.")
             return
         out_csv = filedialog.asksaveasfilename(
-            title="Save peak table as CSV",
+            title="Save export base name",
             defaultextension=".csv",
             filetypes=[("CSV","*.csv")]
         )
         if not out_csv:
             return
+        paths = data_io.derive_export_paths(out_csv)
 
         areas = [pseudo_voigt_area(p.height, p.fwhm, p.eta) for p in self.peaks]
         total_area = float(np.sum(areas)) if areas else 1.0
@@ -2332,9 +2534,24 @@ class PeakFitApp:
         rmse = float(np.sqrt(np.mean((y_target[mask] - y_fit[mask]) ** 2))) if mask is not None else float("nan")
 
         rows = []
-        fname = self.file_label.cget("text")
+        fname = self.current_file.name if self.current_file else ""
+        opts = self._solver_options()
+        solver = self.solver_choice.get()
+        perf_extras = {
+            "perf_numba": bool(self.perf_numba.get()),
+            "perf_gpu": bool(self.perf_gpu.get()),
+            "perf_cache_baseline": bool(self.perf_cache_baseline.get()),
+            "perf_seed_all": bool(self.perf_seed_all.get()),
+            "perf_max_workers": int(self.perf_max_workers.get()),
+        }
+        center_bounds = (self.fit_xmin, self.fit_xmax) if (opts.get("centers_in_window") or opts.get("bound_centers_to_window")) else (np.nan, np.nan)
+        if self.x is not None and self.x.size > 1:
+            med_dx = float(np.median(np.diff(np.sort(self.x))))
+        else:
+            med_dx = 0.0
+        fwhm_lo = opts.get("min_fwhm", max(1e-6, 2.0 * med_dx))
         for i, (p, a) in enumerate(zip(self.peaks, areas), 1):
-            rows.append({
+            row = {
                 "file": fname,
                 "peak": i,
                 "center": p.center,
@@ -2352,28 +2569,54 @@ class PeakFitApp:
                 "als_p": float(self.als_asym.get()),
                 "fit_xmin": self.fit_xmin if self.fit_xmin is not None else float(self.x.min()),
                 "fit_xmax": self.fit_xmax if self.fit_xmax is not None else float(self.x.max()),
-            })
-        pd.DataFrame(rows).to_csv(out_csv, index=False)
+                "solver_choice": solver,
+                "solver_loss": opts.get("loss", np.nan),
+                "solver_weight": opts.get("weights", np.nan),
+                "solver_fscale": opts.get("f_scale", np.nan),
+                "solver_maxfev": opts.get("maxfev", np.nan),
+                "solver_restarts": opts.get("restarts", np.nan),
+                "solver_jitter_pct": opts.get("jitter_pct", np.nan),
+                "use_baseline": bool(self.use_baseline.get()),
+                "baseline_mode": self.baseline_mode.get(),
+                "baseline_uses_fit_range": bool(self.baseline_use_range.get()),
+                "als_niter": int(self.als_niter.get()),
+                "als_thresh": float(self.als_thresh.get()),
+                **perf_extras,
+                "bounds_center_lo": center_bounds[0],
+                "bounds_center_hi": center_bounds[1],
+                "bounds_fwhm_lo": fwhm_lo,
+                "bounds_height_lo": 0.0,
+                "bounds_height_hi": np.nan,
+                "x_scale": opts.get("x_scale", np.nan),
+            }
+            rows.append(row)
+        peak_csv = data_io.build_peak_table(rows)
+        with open(paths["fit"], "w", encoding="utf-8", newline="") as fh:
+            fh.write(peak_csv)
 
-        # Trace CSV
-        trace_path = str(Path(out_csv).with_name(Path(out_csv).stem + "_trace.csv"))
-        df = pd.DataFrame({
-            "x": self.x,
-            "y_raw": self.y_raw,
-            "baseline": base,
-            "y_corr": y_corr,
-            "y_target": y_target,   # data actually used for fitting
-            "y_fit": y_fit
-        })
-        for k, v in comp_cols.items():
-            df[k] = v
-        df.to_csv(trace_path, index=False)
+        trace_csv = data_io.build_trace_table(
+            self.x, self.y_raw, base if self.use_baseline.get() else None, self.peaks
+        )
+        with open(paths["trace"], "w", encoding="utf-8", newline="") as fh:
+            fh.write(trace_csv)
 
-        messagebox.showinfo("Export", f"Saved:\n{out_csv}\n{trace_path}")
+        try:
+            self._maybe_export_uncertainty(
+                Path(paths["unc_txt"]), Path(paths["unc_csv"]), Path(paths["unc_band"]), rmse
+            )
+        except Exception as e:  # pragma: no cover - defensive
+            self.log(f"Uncertainty export failed: {e}", level="WARN")
+
+        messagebox.showinfo(
+            "Export",
+            f"Saved:\n{paths['fit']}\n{paths['trace']}\n{paths['unc_txt']}\n{paths['unc_csv']}",
+        )
 
     # ----- Plot -----
     def toggle_components(self):
         self.components_visible = not self.components_visible
+        self.cfg["ui_show_components"] = self.components_visible
+        save_config(self.cfg)
         self.refresh_plot()
 
     def refresh_plot(self):
@@ -2419,14 +2662,14 @@ class PeakFitApp:
             self.ax.axvspan(lo, hi, color="0.8", alpha=0.25, lw=0)
 
         if self.show_ci_band and self.ci_band is not None:
-            xb, lob, hib = self.ci_band
+            xb, lob, hib, _ = self.ci_band
             self.ax.fill_between(xb, lob, hib, alpha=0.18, label="Uncertainty band")
 
         # Legend toggle
         leg = self.ax.get_legend()
         if self.show_legend_var.get():
             try:
-                self.ax.legend(loc="best")
+                self.ax.legend(loc="best", prop=FontProperties(family="Arial"))
             except Exception:
                 pass
         else:


### PR DESCRIPTION
## Summary
- move action bar to left and show current file path on the right with tooltipped ellipsis
- export fit, trace, and uncertainty data with canonical filenames and no blank lines; add tidy uncertainty CSV and band
- batch runner writes all outputs to chosen directory, respects fit-range baseline, and records stderr/CI for each peak

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aeb4e7c64483308c5b410368e88b70