### PR TITLE
Ensure batch fits match single-runner output

### DIFF
--- a/core/fit_api.py
+++ b/core/fit_api.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import copy
+from dataclasses import replace
+from typing import List, Optional
+
+import numpy as np
+
+from .peaks import Peak
+from . import models
+from .weights import noise_weights
+from .residuals import build_residual
+from fit import orchestrator
+from fit.bounds import pack_theta_bounds
+
+
+def run_fit_consistent(
+    x: np.ndarray,
+    y: np.ndarray,
+    peaks_in: List[Peak],
+    cfg: dict,
+    baseline: Optional[np.ndarray],
+    mode: str,
+    fit_mask: np.ndarray,
+    reheight: bool = False,
+    rng_seed: Optional[int] = None,
+    verbose: bool = False,
+) -> dict:
+    """Run a fit mirroring the single-file GUI path."""
+
+    x = np.asarray(x, float)
+    y = np.asarray(y, float)
+    mask = np.asarray(fit_mask, bool)
+    if mask.shape != x.shape:
+        raise ValueError("fit_mask shape mismatch")
+    if baseline is not None:
+        baseline = np.asarray(baseline, float)
+        if baseline.shape != x.shape:
+            raise ValueError("baseline shape mismatch")
+
+    peaks0 = copy.deepcopy(peaks_in)
+    if reheight:
+        sig = y - (baseline if baseline is not None else 0.0)
+        med = float(np.median(sig))
+        for i, pk in enumerate(peaks0):
+            if getattr(pk, "lock_height", False):
+                continue
+            y_at = float(np.interp(pk.center, x, sig))
+            peaks0[i] = replace(pk, height=max(y_at - med, 1e-6))
+
+    x_fit = x[mask]
+    y_fit = y[mask]
+    base_fit = baseline[mask] if baseline is not None else None
+
+    solver_name = cfg.get("solver", "modern_vp")
+    solver_opts = dict(cfg.get(solver_name, {}))
+    opts = dict(solver_opts)
+    opts.update(
+        {
+            "solver": solver_name,
+            "loss": cfg.get("solver_loss", opts.get("loss", "linear")),
+            "weights": cfg.get("solver_weight", opts.get("weights", "none")),
+            "f_scale": cfg.get("solver_fscale", opts.get("f_scale", 1.0)),
+            "maxfev": cfg.get("solver_maxfev", opts.get("maxfev", 20000)),
+            "restarts": 1,
+            "jitter_pct": 0.0,
+        }
+    )
+
+    p0, (lo, hi) = pack_theta_bounds(peaks0, x_fit, opts)
+
+    restarts = int(cfg.get("solver_restarts", 1))
+    jitter_pct = float(cfg.get("solver_jitter_pct", 0.0))
+    perf_seed = bool(cfg.get("perf_seed_all", False))
+    base_seed = rng_seed if perf_seed else None
+
+    y_target = y_fit - (base_fit if base_fit is not None else 0.0)
+    weights = noise_weights(y_target, opts.get("weights", "none"))
+
+    best_res = None
+    best_theta = None
+    best_rmse = np.inf
+    for r in range(max(1, restarts)):
+        seed = (base_seed + r) if base_seed is not None else None
+        rng = np.random.default_rng(seed)
+        theta_start = p0.copy()
+        if jitter_pct:
+            for i, pk in enumerate(peaks0):
+                if not pk.lock_center:
+                    theta_start[4 * i] += (
+                        theta_start[4 * i + 2]
+                        * (jitter_pct / 100.0)
+                        * rng.standard_normal()
+                    )
+                theta_start[4 * i + 1] *= 1.0 + (jitter_pct / 100.0) * rng.standard_normal()
+                if not pk.lock_width:
+                    theta_start[4 * i + 2] *= 1.0 + (
+                        jitter_pct / 100.0
+                    ) * rng.standard_normal()
+            theta_start = np.clip(theta_start, lo, hi)
+
+        peaks_start = []
+        for i, pk in enumerate(peaks0):
+            c, h, w, e = theta_start[4 * i : 4 * (i + 1)]
+            peaks_start.append(Peak(c, h, w, e, pk.lock_center, pk.lock_width))
+
+        y_solver = y_target if mode == "subtract" else y_fit
+        base_solver = None if mode == "subtract" else base_fit
+        res = orchestrator.run_fit_with_fallbacks(
+            x_fit, y_solver, peaks_start, mode, base_solver, opts
+        )
+        theta = np.asarray(res.theta, float)
+        resid_fn = build_residual(x_fit, y_fit, res.peaks_out, mode, base_fit, "linear", None)
+        rmse = float(np.sqrt(np.mean(resid_fn(theta) ** 2))) if theta.size else float("nan")
+        if rmse < best_rmse:
+            best_rmse = rmse
+            best_theta = theta.copy()
+            best_res = res
+
+    theta = best_theta if best_theta is not None else p0.copy()
+    clipped = np.clip(theta, lo, hi)
+    clipped_after = bool(np.any(np.abs(clipped - theta) > 1e-12))
+    theta = clipped
+    for i, pk in enumerate(peaks0):
+        if pk.lock_center:
+            theta[4 * i] = p0[4 * i]
+        if pk.lock_width:
+            theta[4 * i + 2] = p0[4 * i + 2]
+
+    assert np.all(theta >= lo - 1e-12) and np.all(theta <= hi + 1e-12)
+
+    peaks_out: List[Peak] = []
+    for i, pk in enumerate(peaks0):
+        c, h, w, e = theta[4 * i : 4 * (i + 1)]
+        peaks_out.append(
+            Peak(c, h, w, e, pk.lock_center, pk.lock_width)
+        )
+
+    resid_fn = build_residual(x_fit, y_fit, peaks_out, mode, base_fit, "linear", None)
+    rmse = float(np.sqrt(np.mean(resid_fn(theta) ** 2))) if theta.size else float("nan")
+
+    baseline_cfg = cfg.get("baseline", {})
+    baseline_params = {
+        "lam": baseline_cfg.get("lam"),
+        "p": baseline_cfg.get("p"),
+        "niter": baseline_cfg.get("niter"),
+        "thresh": baseline_cfg.get("thresh"),
+        "thresh_hit": bool(baseline_cfg.get("thresh_hit", False)),
+    }
+
+    if verbose:
+        xmin = float(x_fit[0]) if x_fit.size else float("nan")
+        xmax = float(x_fit[-1]) if x_fit.size else float("nan")
+        print(
+            "mask_len=%d window=[%g,%g] bounds=(%g,%g) p0_head=%s p0_tail=%s restarts=%d jitter_pct=%g rmse=%g clipped=%s"
+            % (
+                mask.sum(),
+                xmin,
+                xmax,
+                lo.min() if lo.size else np.nan,
+                hi.max() if hi.size else np.nan,
+                p0[:3],
+                p0[-3:] if p0.size >= 3 else p0,
+                restarts,
+                jitter_pct,
+                rmse,
+                clipped_after,
+            )
+        )
+
+    return {
+        "peaks_out": peaks_out,
+        "rmse": rmse,
+        "theta": theta,
+        "bounds": (lo, hi),
+        "p0": p0,
+        "mask_len": int(mask.sum()),
+        "baseline_params": baseline_params,
+        "restarts_used": restarts,
+        "jitter_pct": jitter_pct,
+        "clipped_after_solve": clipped_after,
+        "fit_ok": bool(best_res.success if best_res is not None else False),
+    }
+

--- a/tests/test_batch_baseline_in_range_parity.py
+++ b/tests/test_batch_baseline_in_range_parity.py
@@ -1,0 +1,74 @@
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from core import models, peaks, signals, fit_api
+from batch import runner
+
+
+def test_batch_baseline_in_range_parity(tmp_path):
+    x = np.linspace(-5, 5, 201)
+    base_true = 0.1 * x + 0.2
+    seeds = [peaks.Peak(-1.0, 1.0, 0.8, 0.2)]
+    y_raw = base_true + models.pv_sum(x, seeds)
+
+    mask = (x >= -2) & (x <= 2)
+    z_sub = signals.als_baseline(y_raw[mask], lam=1e5, p=0.01, niter=10, tol=0.0)
+    baseline_full = np.interp(x, x[mask], z_sub, left=z_sub[0], right=z_sub[-1])
+
+    cfg = {
+        "solver": "modern_vp",
+        "solver_loss": "linear",
+        "solver_weight": "none",
+        "solver_maxfev": 100,
+        "solver_restarts": 1,
+        "solver_jitter_pct": 0,
+        "baseline": {"lam": 1e5, "p": 0.01, "niter": 10, "thresh": 0.0},
+        "perf_seed_all": True,
+    }
+
+    fpath = tmp_path / "spec.csv"
+    np.savetxt(fpath, np.column_stack([x, y_raw]), delimiter=",")
+    seed = abs(hash(str(fpath.resolve()))) & 0xFFFFFFFF
+
+    res_single = fit_api.run_fit_consistent(
+        x,
+        y_raw,
+        seeds,
+        cfg,
+        baseline_full,
+        "add",
+        mask,
+        rng_seed=seed,
+    )
+
+    cfg_batch = {
+        **cfg,
+        "peaks": [p.__dict__ for p in seeds],
+        "mode": "add",
+        "baseline_uses_fit_range": True,
+        "fit_xmin": -2,
+        "fit_xmax": 2,
+        "output_dir": str(tmp_path),
+        "output_base": "out",
+        "save_traces": False,
+    }
+    runner.run([str(fpath)], cfg_batch, progress=None, log=None)
+
+    df = pd.read_csv(tmp_path / "out_fit.csv").sort_values("peak")
+    theta_batch = []
+    for _, row in df.iterrows():
+        theta_batch.extend([row["center"], row["height"], row["fwhm"], row["eta"]])
+    theta_batch = np.array(theta_batch)
+    rmse_batch = df["rmse"].iloc[0]
+
+    assert np.allclose(theta_batch, res_single["theta"], rtol=1e-6, atol=1e-8)
+    assert abs(rmse_batch - res_single["rmse"]) <= 1e-8
+
+    z_sub_batch = signals.als_baseline(y_raw[mask], lam=1e5, p=0.01, niter=10, tol=0.0)
+    baseline_full_batch = np.interp(x, x[mask], z_sub_batch, left=z_sub_batch[0], right=z_sub_batch[-1])
+    assert np.linalg.norm(baseline_full_batch - baseline_full) < 1e-10
+

--- a/tests/test_batch_bounds_enforced.py
+++ b/tests/test_batch_bounds_enforced.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+import numpy as np
+
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from core import models, peaks, fit_api
+
+
+def test_batch_bounds_enforced():
+    x = np.linspace(-4, 4, 101)
+    seed = peaks.Peak(0.0, 1.0, 1.0, 0.5, lock_center=True, lock_width=True)
+    y = models.pv_sum(x, [seed])
+    mask = np.ones_like(x, bool)
+    cfg = {
+        "solver": "modern_vp",
+        "solver_loss": "linear",
+        "solver_weight": "none",
+        "solver_maxfev": 50,
+        "solver_restarts": 3,
+        "solver_jitter_pct": 20,
+        "modern_vp": {"min_fwhm": 0.9, "max_fwhm": 1.1, "bound_centers_to_window": True},
+    }
+    res = fit_api.run_fit_consistent(x, y, [seed], cfg, None, "subtract", mask, rng_seed=0)
+    theta = res["theta"]
+    lo, hi = res["bounds"]
+    assert np.all(theta >= lo - 1e-12)
+    assert np.all(theta <= hi + 1e-12)
+    assert abs(theta[0] - seed.center) <= 1e-12
+    assert abs(theta[2] - seed.fwhm) <= 1e-12
+

--- a/tests/test_batch_jitter_lock_respect.py
+++ b/tests/test_batch_jitter_lock_respect.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+import numpy as np
+
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from core import models, peaks, fit_api
+
+
+def test_batch_jitter_lock_respect():
+    x = np.linspace(-5, 5, 201)
+    seeds = [
+        peaks.Peak(-1.0, 1.0, 0.8, 0.3, lock_center=True, lock_width=True),
+        peaks.Peak(1.0, 0.5, 0.6, 0.2),
+    ]
+    y = models.pv_sum(x, seeds)
+    mask = np.ones_like(x, bool)
+    cfg = {
+        "solver": "modern_vp",
+        "solver_loss": "linear",
+        "solver_weight": "none",
+        "solver_maxfev": 100,
+        "solver_restarts": 3,
+        "solver_jitter_pct": 10,
+        "perf_seed_all": True,
+    }
+    res = fit_api.run_fit_consistent(x, y, seeds, cfg, None, "subtract", mask, rng_seed=0)
+    theta = res["theta"]
+    assert abs(theta[0] - seeds[0].center) <= 1e-12
+    assert abs(theta[2] - seeds[0].fwhm) <= 1e-12
+

--- a/tests/test_batch_single_parity.py
+++ b/tests/test_batch_single_parity.py
@@ -1,0 +1,91 @@
+import itertools
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from core import models, peaks, signals, fit_api
+from batch import runner
+
+
+@pytest.mark.parametrize(
+    "mode,loss,weight,restarts",
+    list(
+        itertools.product(
+            ["add", "subtract"],
+            ["linear", "soft_l1"],
+            ["none", "poisson"],
+            [1, 3],
+        )
+    ),
+)
+def test_batch_single_parity(mode, loss, weight, restarts, tmp_path):
+    x = np.linspace(-5, 5, 201)
+    seeds = [
+        peaks.Peak(-1.0, 1.0, 0.8, 0.2, lock_center=True),
+        peaks.Peak(1.0, 0.6, 0.5, 0.3, lock_width=True),
+    ]
+    baseline_true = 0.1 * x + 0.2
+    y_raw = baseline_true + models.pv_sum(x, seeds)
+    mask = np.ones_like(x, bool)
+    base = signals.als_baseline(y_raw, lam=1e5, p=0.001, niter=10, tol=0.0)
+
+    cfg = {
+        "solver": "modern_vp",
+        "solver_loss": loss,
+        "solver_weight": weight,
+        "solver_fscale": 1.0,
+        "solver_maxfev": 100,
+        "solver_restarts": restarts,
+        "solver_jitter_pct": 10,
+        "baseline": {"lam": 1e5, "p": 0.001, "niter": 10, "thresh": 0.0},
+        "perf_seed_all": True,
+    }
+
+    fpath = tmp_path / "spec.csv"
+    np.savetxt(fpath, np.column_stack([x, y_raw]), delimiter=",")
+    seed = abs(hash(str(fpath.resolve()))) & 0xFFFFFFFF
+
+    res_single = fit_api.run_fit_consistent(
+        x,
+        y_raw,
+        seeds,
+        cfg,
+        base,
+        mode,
+        mask,
+        rng_seed=seed,
+    )
+
+    cfg_batch = {
+        **cfg,
+        "peaks": [p.__dict__ for p in seeds],
+        "mode": mode,
+        "output_dir": str(tmp_path),
+        "output_base": "out",
+        "save_traces": False,
+    }
+    runner.run([str(fpath)], cfg_batch, progress=None, log=None)
+    df = pd.read_csv(tmp_path / "out_fit.csv").sort_values("peak")
+    theta_batch = []
+    for _, row in df.iterrows():
+        theta_batch.extend([row["center"], row["height"], row["fwhm"], row["eta"]])
+    theta_batch = np.array(theta_batch)
+    rmse_batch = df["rmse"].iloc[0]
+
+    theta_single = res_single["theta"]
+    rmse_single = res_single["rmse"]
+
+    assert abs(rmse_batch - rmse_single) <= 1e-8
+    delta = np.abs(theta_batch - theta_single)
+    rel = delta / np.maximum(1e-12, np.abs(theta_single))
+    assert np.all((delta <= 1e-8) | (rel <= 1e-6))
+    for i, pk in enumerate(seeds):
+        if pk.lock_center:
+            assert abs(theta_batch[4 * i] - pk.center) <= 1e-12
+        if pk.lock_width:
+            assert abs(theta_batch[4 * i + 2] - pk.fwhm) <= 1e-12
+


### PR DESCRIPTION
## Summary
- Add `run_fit_consistent` for shared parameter packing, bounds, jitter, and residual logic
- Rework batch runner to deep-copy seeds, apply fit-range baselines, and call the unified fit API
- Add parity and guardrail tests for batch vs single fitting, bounds, baseline usage, and jitter lock respect

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aee4cf3edc83308e24535844fe45d0