### PR TITLE
Implement solver-specific Step adapters with parity tests

### DIFF
--- a/core/fit_api.py
+++ b/core/fit_api.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import copy
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from typing import List, Optional
 
 import numpy as np
@@ -352,4 +352,245 @@ def build_residual_and_jacobian(payload: dict, solver_choice: str) -> dict:
         "locked_mask": locked_mask,
         "residual_jac": residual_jac,
     }
+
+
+@dataclass
+class StepResult:
+    accepted: bool
+    cost0: float
+    cost1: float
+    step_norm: float
+    lambda_used: float | None
+    backtracks: int
+    reason: str
+
+
+def _map_reason(reason: str) -> str:
+    if reason in ("accepted", "ok"):
+        return "ok"
+    if reason == "nonfinite":
+        return "nan_guard"
+    return reason
+
+
+def step_classic(
+    x: np.ndarray,
+    y: np.ndarray,
+    peaks: List[Peak],
+    mode: str,
+    baseline: np.ndarray | None,
+    options: dict,
+):
+    from fit import classic
+
+    prep = classic.prepare_state(x, y, peaks, mode, baseline, options)
+    state = prep["state"]
+    cost0 = prep["cost"]
+    state, ok, c0, c1, info = classic.iterate(state)
+    theta = state["theta"]
+    peaks_out = state["peaks"]
+    res = StepResult(
+        accepted=ok,
+        cost0=float(c0),
+        cost1=float(c1),
+        step_norm=float(info.get("step_norm", 0.0)),
+        lambda_used=float(info.get("lambda", 0.0)),
+        backtracks=int(info.get("backtracks", 0)),
+        reason=_map_reason(info.get("reason", "ok")),
+    )
+    return theta, peaks_out, res
+
+
+def step_modern_vp(
+    x: np.ndarray,
+    y: np.ndarray,
+    peaks: List[Peak],
+    mode: str,
+    baseline: np.ndarray | None,
+    options: dict,
+):
+    from fit import modern_vp
+
+    prep = modern_vp.prepare_state(x, y, peaks, mode, baseline, options)
+    state = prep["state"]
+    state, ok, c0, c1, info = modern_vp.iterate(state)
+    theta = state["theta"]
+    peaks_out = state["peaks"]
+    res = StepResult(
+        accepted=ok,
+        cost0=float(c0),
+        cost1=float(c1),
+        step_norm=float(info.get("step_norm", 0.0)),
+        lambda_used=float(info.get("lambda", 0.0)),
+        backtracks=int(info.get("backtracks", 0)),
+        reason=_map_reason(info.get("reason", "ok")),
+    )
+    return theta, peaks_out, res
+
+
+def step_modern_trf(
+    x: np.ndarray,
+    y: np.ndarray,
+    peaks: List[Peak],
+    mode: str,
+    baseline: np.ndarray | None,
+    options: dict,
+):
+    from scipy.optimize import least_squares
+    from fit.modern import _to_solver_vectors
+    from fit.utils import robust_cost
+
+    x = np.asarray(x, float)
+    y = np.asarray(y, float)
+    base = np.asarray(baseline, float) if baseline is not None else None
+
+    loss = options.get("loss", "linear")
+    weight_mode = options.get("weights", "none")
+    f_scale = float(options.get("f_scale", 1.0))
+
+    base_arr = base if base is not None else 0.0
+    y_target = y - base_arr
+    weights = noise_weights(y_target, weight_mode)
+
+    theta0_full, bounds_full = pack_theta_bounds(peaks, x, options)
+    dx_med = float(np.median(np.diff(x))) if x.size > 1 else 1.0
+    fwhm_min = max(float(options.get("min_fwhm", 1e-6)), 2.0 * dx_med)
+    theta0, bounds, x_scale, indices = _to_solver_vectors(
+        theta0_full, bounds_full, peaks, fwhm_min
+    )
+
+    from core.residuals import build_residual_jac as _brj
+    resid_jac_fn = _brj(x, y, peaks, mode, base, weights)
+
+    def fun(t):
+        r, _ = resid_jac_fn(t)
+        return r
+
+    def jac(t):
+        _, J = resid_jac_fn(t)
+        return J
+
+    r0, _ = resid_jac_fn(theta0)
+    cost0 = robust_cost(r0, loss, f_scale)
+    res = least_squares(
+        fun,
+        theta0,
+        jac=jac,
+        method="trf",
+        loss=loss,
+        f_scale=f_scale,
+        bounds=bounds,
+        x_scale=x_scale,
+        max_nfev=2,
+    )
+    r1 = res.fun
+    cost1 = robust_cost(r1, loss, f_scale)
+    theta_full = theta0_full.copy()
+    theta_full[indices] = res.x
+    step_norm = float(np.linalg.norm(res.x - theta0))
+    accepted = np.isfinite(cost1) and cost1 < cost0 and step_norm > 1e-14
+    reason = "ok" if accepted else "no_decrease"
+    if not accepted:
+        theta_full = theta0_full
+        cost1 = cost0
+        step_norm = 0.0
+
+    peaks_out: List[Peak] = []
+    for i, pk in enumerate(peaks):
+        c, h, w, e = theta_full[4 * i : 4 * (i + 1)]
+        peaks_out.append(Peak(c, h, w, e, pk.lock_center, pk.lock_width))
+
+    diag = StepResult(
+        accepted=accepted,
+        cost0=float(cost0),
+        cost1=float(cost1),
+        step_norm=step_norm,
+        lambda_used=None,
+        backtracks=0,
+        reason=_map_reason(reason),
+    )
+    return theta_full, peaks_out, diag
+
+
+def step_lmfit_vp(
+    x: np.ndarray,
+    y: np.ndarray,
+    peaks: List[Peak],
+    mode: str,
+    baseline: np.ndarray | None,
+    options: dict,
+):
+    try:
+        from fit import lmfit_backend
+    except Exception as exc:  # pragma: no cover - optional dependency missing
+        theta0, _ = pack_theta_bounds(peaks, x, options)
+        diag = StepResult(
+            accepted=False,
+            cost0=float("nan"),
+            cost1=float("nan"),
+            step_norm=0.0,
+            lambda_used=None,
+            backtracks=0,
+            reason=str(exc),
+        )
+        return theta0, peaks, diag
+
+    x = np.asarray(x, float)
+    y = np.asarray(y, float)
+    base = np.asarray(baseline, float) if baseline is not None else None
+
+    res = lmfit_backend.solve(x, y, peaks, mode, base, {**options, "maxfev": 1})
+    theta1 = res["theta"]
+    peaks_out = [
+        Peak(theta1[4 * i], theta1[4 * i + 1], theta1[4 * i + 2], theta1[4 * i + 3])
+        for i in range(len(peaks))
+    ]
+
+    # Estimate cost0 via residual before step
+    resid0 = build_residual(x, y, peaks, mode, base, "linear", None)
+    theta0, _ = pack_theta_bounds(peaks, x, options)
+    r0 = resid0(theta0)
+    cost0 = 0.5 * float(r0 @ r0)
+    cost1 = res.get("cost", cost0)
+    step_norm = float(np.linalg.norm(theta1 - theta0))
+    accepted = np.isfinite(cost1) and cost1 < cost0 and step_norm > 1e-14
+    if not accepted:
+        theta1 = theta0
+        peaks_out = peaks
+        cost1 = cost0
+        step_norm = 0.0
+
+    diag = StepResult(
+        accepted=accepted,
+        cost0=float(cost0),
+        cost1=float(cost1),
+        step_norm=step_norm,
+        lambda_used=None,
+        backtracks=0,
+        reason="ok" if accepted else "no_decrease",
+    )
+    return theta1, peaks_out, diag
+
+
+STEP_DISPATCH = {
+    "classic": step_classic,
+    "modern_trf": step_modern_trf,
+    "modern_vp": step_modern_vp,
+    "lmfit_vp": step_lmfit_vp,
+}
+
+
+def step_router(
+    solver: str,
+    x: np.ndarray,
+    y: np.ndarray,
+    peaks: List[Peak],
+    mode: str,
+    baseline: np.ndarray | None,
+    options: dict,
+):
+    func = STEP_DISPATCH.get(solver)
+    if func is None:
+        raise ValueError(f"unknown solver '{solver}'")
+    return func(x, y, peaks, mode, baseline, options)
 

--- a/tests/test_step_classic_parity.py
+++ b/tests/test_step_classic_parity.py
@@ -1,0 +1,64 @@
+import pathlib, sys
+
+import numpy as np
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from core.peaks import Peak
+from core.models import pv_sum
+from core.fit_api import step_classic, build_residual_and_jacobian
+from fit.bounds import pack_theta_bounds
+
+
+def _gn_reference(payload):
+    info = build_residual_and_jacobian(payload, "classic")
+    th0 = info["theta"]
+    r0, J0 = info["residual_jac"](th0)
+    free = ~info["locked_mask"]
+    Jf = J0[:, free]
+    delta_f = np.linalg.solve(Jf.T @ Jf + np.eye(Jf.shape[1]), -Jf.T @ r0)
+    delta = np.zeros_like(th0)
+    delta[free] = delta_f
+    th1 = np.clip(th0 + delta, info["bounds"][0], info["bounds"][1])
+    return th0, th1, delta, 0.5 * float(r0 @ r0)
+
+
+def test_classic_step_parity():
+    x = np.linspace(0.0, 60.0, 400)
+    true = [Peak(20, 5, 5, 0.5), Peak(25, 2, 5, 0.3)]
+    start = [Peak(19, 4, 6, 0.5, True), Peak(26, 1.5, 6, 0.3)]
+    y = pv_sum(x, true)
+
+    payload = {"x": x, "y": y, "peaks": start, "mode": "add", "baseline": None, "options": {}}
+    th0, th1_ref, delta_ref, cost0_ref = _gn_reference(payload)
+
+    theta, peaks_out, res = step_classic(x, y, start, "add", None, {})
+
+    assert res.accepted
+    assert res.cost1 < res.cost0
+    assert res.step_norm > 0
+    assert np.all(np.isfinite(theta))
+
+    theta0, bounds = pack_theta_bounds(start, x, {})
+    lo, hi = bounds
+    assert np.all(theta >= lo - 1e-12) and np.all(theta <= hi + 1e-12)
+    assert theta[0] == pytest.approx(theta0[0])  # locked center
+
+    delta_step = theta - th0
+    cos = float(np.dot(delta_step, delta_ref)) / (
+        np.linalg.norm(delta_step) * np.linalg.norm(delta_ref)
+    )
+    assert cos >= 0.95
+
+    info = build_residual_and_jacobian(payload, "classic")
+    r0, _ = info["residual_jac"](info["theta"])
+    cost_ref = 0.5 * float(r0 @ r0)
+    assert res.cost0 == pytest.approx(cost_ref)
+
+    payload_sub = {"x": x, "y": y, "peaks": start, "mode": "subtract", "baseline": None, "options": {}}
+    info_sub = build_residual_and_jacobian(payload_sub, "classic")
+    r0s, _ = info_sub["residual_jac"](info_sub["theta"])
+    cost_sub = 0.5 * float(r0s @ r0s)
+    _, _, res_sub = step_classic(x, y, start, "subtract", None, {})
+    assert res_sub.cost0 == pytest.approx(cost_sub)

--- a/tests/test_step_parity_trf_vp_lmfit.py
+++ b/tests/test_step_parity_trf_vp_lmfit.py
@@ -1,0 +1,95 @@
+import pathlib, sys
+
+import numpy as np
+import pytest
+from scipy.optimize import least_squares
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from core.peaks import Peak
+from core.models import pv_sum
+from core.fit_api import step_modern_trf, step_modern_vp, step_lmfit_vp
+from fit.bounds import pack_theta_bounds
+from fit.modern import _to_solver_vectors
+from core.residuals import build_residual_jac
+from core.weights import noise_weights
+from fit.utils import robust_cost
+
+
+def _scenario():
+    x = np.linspace(0.0, 50.0, 200)
+    true = [Peak(15, 4, 4, 0.4), Peak(28, 2, 5, 0.3)]
+    start = [Peak(14, 3, 5, 0.4, True), Peak(29, 1.5, 6, 0.3)]
+    y = pv_sum(x, true)
+    return x, y, start
+
+
+def test_step_parity_trf():
+    x, y, start = _scenario()
+    theta_step, peaks_step, res = step_modern_trf(x, y, start, "subtract", None, {})
+    assert res.accepted
+    assert res.cost1 < res.cost0
+
+    weights = noise_weights(y, "none")
+    theta0_full, bounds_full = pack_theta_bounds(start, x, {})
+    dx_med = float(np.median(np.diff(x))) if x.size > 1 else 1.0
+    fwhm_min = max(1e-6, 2.0 * dx_med)
+    theta0, bounds, x_scale, idx = _to_solver_vectors(theta0_full, bounds_full, start, fwhm_min)
+    rj = build_residual_jac(x, y, start, "subtract", None, weights)
+
+    def fun(t):
+        r, _ = rj(t)
+        return r
+
+    def jac(t):
+        _, J = rj(t)
+        return J
+
+    res_ref = least_squares(
+        fun,
+        theta0,
+        jac=jac,
+        method="trf",
+        loss="linear",
+        f_scale=1.0,
+        bounds=bounds,
+        x_scale=x_scale,
+        max_nfev=2,
+    )
+    theta_ref = theta0_full.copy()
+    theta_ref[idx] = res_ref.x
+    assert np.allclose(theta_step, theta_ref, rtol=1e-6, atol=1e-8)
+    lo, hi = bounds_full
+    assert np.all(theta_step >= lo - 1e-12) and np.all(theta_step <= hi + 1e-12)
+
+
+def test_step_parity_vp():
+    x, y, start = _scenario()
+    theta_step, peaks_step, res = step_modern_vp(x, y, start, "subtract", None, {})
+    assert res.accepted
+    assert res.cost1 < res.cost0
+
+    from fit import modern_vp
+
+    prep = modern_vp.prepare_state(x, y, start, "subtract", None, {})["state"]
+    state_ref, ok, c0, c1, info = modern_vp.iterate(prep)
+    theta_ref = state_ref["theta"]
+    assert np.allclose(theta_step, theta_ref, rtol=1e-6, atol=1e-8)
+
+
+def test_step_parity_lmfit():
+    try:
+        import lmfit  # noqa: F401
+    except Exception:
+        pytest.skip("lmfit not installed")
+
+    x, y, start = _scenario()
+    theta_step, peaks_step, res = step_lmfit_vp(x, y, start, "subtract", None, {})
+    assert res.accepted
+    assert res.cost1 < res.cost0
+
+    from fit import lmfit_backend
+
+    ref = lmfit_backend.solve(x, y, start, "subtract", None, {"maxfev": 1})
+    theta_ref = ref["theta"]
+    assert np.allclose(theta_step, theta_ref, rtol=1e-6, atol=1e-8)

--- a/ui/app.py
+++ b/ui/app.py
@@ -214,7 +214,12 @@ from scipy.signal import find_peaks
 
 from core import signals, data_io
 from core.residuals import build_residual, jacobian_fd
-from core.fit_api import build_residual_and_jacobian
+from core.fit_api import (
+    step_classic,
+    step_modern_trf,
+    step_modern_vp,
+    step_lmfit_vp,
+)
 from fit import orchestrator, classic, modern_vp, modern
 try:  # optional
     from fit import lmfit_backend
@@ -2060,60 +2065,33 @@ class PeakFitApp:
 
         options = self._solver_options()
         solver = self.solver_choice.get()
-        options["solver"] = solver
 
         self.set_busy(True, "Stepping…")
-        payload = {
-            "x": x_fit,
-            "y": y_fit,
-            "peaks": self.peaks,
-            "mode": mode,
-            "baseline": base_fit,
-            "options": options,
-        }
         try:
-            info = build_residual_and_jacobian(payload, solver)
-            theta = info["theta"]
-            lo, hi = info["bounds"]
-            locked = info["locked_mask"]
-            r0, J0 = info["residual_jac"](theta)
+            if solver == "classic":
+                theta, peaks_new, res = step_classic(x_fit, y_fit, self.peaks, mode, base_fit, options)
+            elif solver == "modern_trf":
+                theta, peaks_new, res = step_modern_trf(x_fit, y_fit, self.peaks, mode, base_fit, options)
+            elif solver == "modern_vp":
+                theta, peaks_new, res = step_modern_vp(x_fit, y_fit, self.peaks, mode, base_fit, options)
+            elif solver == "lmfit_vp":
+                theta, peaks_new, res = step_lmfit_vp(x_fit, y_fit, self.peaks, mode, base_fit, options)
+            else:  # pragma: no cover - unknown solver
+                raise ValueError(f"unknown solver '{solver}'")
         except Exception as e:  # pragma: no cover - UI feedback only
             self.set_busy(False, "Step failed.")
             messagebox.showerror("Step", f"Step failed:\n{e}")
             self.log(f"Step failed: {e}", level="ERROR")
             return
 
-        lam = 1.0
-        cost0 = 0.5 * float(r0 @ r0)
-        free = ~locked
-        Jf = J0[:, free]
-        try:
-            delta_f = np.linalg.solve(Jf.T @ Jf + lam * np.eye(Jf.shape[1]), -Jf.T @ r0)
-        except np.linalg.LinAlgError:  # pragma: no cover - fallback
-            delta_f, *_ = np.linalg.lstsq(
-                Jf.T @ Jf + lam * np.eye(Jf.shape[1]), -Jf.T @ r0, rcond=None
-            )
-        delta = np.zeros_like(theta)
-        delta[free] = delta_f
-        theta_try = np.clip(theta + delta, lo, hi)
-        r1, _ = info["residual_jac"](theta_try)
-        cost1 = 0.5 * float(r1 @ r1)
-
-        if cost1 < cost0:
-            j = 0
-            for pk in self.peaks:
-                c, h, w, eta = theta_try[j:j+4]; j += 4
-                if not pk.lock_center:
-                    pk.center = float(c)
-                pk.height = float(h)
-                if not pk.lock_width:
-                    pk.fwhm = float(w)
-                pk.eta = float(eta)
+        if res.accepted:
+            self.peaks[:] = peaks_new
             self.refresh_tree(keep_selection=True)
             self.refresh_plot()
-            msg = f"{solver} Step accepted: Δcost={cost0 - cost1:.3g}, λ={lam:.3g}"
+            lam = res.lambda_used if res.lambda_used is not None else 0.0
+            msg = f"Step accepted (Δcost={res.cost0 - res.cost1:.3g}, λ={lam:.3g}, backtracks={res.backtracks})"
         else:
-            msg = f"{solver} Step rejected; try increasing λ"
+            msg = f"Step rejected: {res.reason}"
 
         self.set_busy(False, msg)
         self.log(msg)


### PR DESCRIPTION
## Summary
- Implement per-solver Step adapters returning `StepResult` diagnostics
- Use SciPy `least_squares` for Modern TRF one-iteration steps and reuse backend state for Classic, VP, and LMFIT
- Wire UI Step button to dispatch to solver-specific adapters and display acceptance diagnostics
- Add parity tests for Classic, TRF, VP, and optional LMFIT step paths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af89841ddc833092c760f9034c717c