### PR TITLE
Restore per-solver Step parity

### DIFF
--- a/tests/test_step_classic_parity.py
+++ b/tests/test_step_classic_parity.py
@@ -1,0 +1,63 @@
+import numpy as np
+import pathlib, sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import pytest
+from core.peaks import Peak
+from core.models import pv_sum
+from core.fit_api import classic_step, build_residual_and_jacobian
+from fit.bounds import pack_theta_bounds
+
+
+def _flatten(peaks):
+    arr = []
+    for p in peaks:
+        arr.extend([p.center, p.height, p.fwhm, p.eta])
+    return np.asarray(arr, float)
+
+
+def test_classic_step_parity():
+    x = np.linspace(0.0, 60.0, 200)
+    true = [Peak(20, 5, 5, 0.5), Peak(25, 2, 5, 0.3)]
+    y = pv_sum(x, true)
+    start = [Peak(19, 4, 6, 0.5, True), Peak(26, 1.5, 6, 0.3)]
+    payload = {"x": x, "y": y, "peaks": start, "mode": "add", "baseline": None, "options": {}}
+
+    theta0_full, (lo, hi) = pack_theta_bounds(start, x, {})
+    theta1, res = classic_step(payload)
+    assert res.accepted and res.cost1 < res.cost0
+    assert res.step_norm > 0 and np.isfinite(res.cost1)
+    assert np.all(theta1 >= lo - 1e-12) and np.all(theta1 <= hi + 1e-12)
+    assert theta1[0] == pytest.approx(theta0_full[0])
+
+    info = build_residual_and_jacobian(payload, "classic")
+    theta = info["theta"]
+    r0, J0 = info["residual_jac"](theta)
+    lam = 1.0
+    free = ~info["locked_mask"]
+    delta_f = np.linalg.solve(J0[:, free].T @ J0[:, free] + lam * np.eye(free.sum()), -J0[:, free].T @ r0)
+    delta_ref = np.zeros_like(theta)
+    delta_ref[free] = delta_f
+    delta_step = theta1 - theta
+    cos = float(np.dot(delta_step, delta_ref) / (np.linalg.norm(delta_step) * np.linalg.norm(delta_ref)))
+    assert cos >= 0.95
+
+    # window parity
+    mask = x < 40
+    payload_win = {"x": x[mask], "y": y[mask], "peaks": start, "mode": "add", "baseline": None, "options": {}}
+    info_win = build_residual_and_jacobian(payload_win, "classic")
+    r_win, _ = info_win["residual_jac"](info_win["theta"])
+    cost_win = 0.5 * float(r_win @ r_win)
+    _, res_win = classic_step(payload_win)
+    assert res_win.cost0 == pytest.approx(cost_win)
+
+    # baseline parity
+    base = np.full_like(x, 0.1)
+    y_plus = y + base
+    payload_base = {"x": x, "y": y_plus, "peaks": start, "mode": "add", "baseline": base, "options": {}}
+    info_base = build_residual_and_jacobian(payload_base, "classic")
+    r_base, _ = info_base["residual_jac"](info_base["theta"])
+    cost_base = 0.5 * float(r_base @ r_base)
+    _, res_base = classic_step(payload_base)
+    assert res_base.cost0 == pytest.approx(cost_base)

--- a/tests/test_step_parity_trf_vp_lmfit.py
+++ b/tests/test_step_parity_trf_vp_lmfit.py
@@ -1,0 +1,69 @@
+import numpy as np
+import pathlib, sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import pytest
+from core.peaks import Peak
+from core.models import pv_sum
+from core.fit_api import modern_trf_step, modern_vp_step, lmfit_step
+from fit.bounds import pack_theta_bounds
+from fit import modern, modern_vp, lmfit_backend
+from core.residuals import build_residual_jac
+from core.weights import noise_weights
+from fit.utils import robust_cost
+from scipy.optimize import least_squares
+
+
+def _problem():
+    x = np.linspace(0.0, 60.0, 200)
+    true = [Peak(20, 5, 5, 0.5), Peak(25, 2, 5, 0.3)]
+    y = pv_sum(x, true)
+    start = [Peak(19, 4, 6, 0.5, True), Peak(26, 1.5, 6, 0.3)]
+    return x, y, start
+
+
+def test_trf_step_parity():
+    x, y, start = _problem()
+    payload = {"x": x, "y": y, "peaks": start, "mode": "add", "baseline": None, "options": {}}
+    theta_step, res = modern_trf_step(payload)
+    assert res.accepted and res.cost1 < res.cost0 and res.step_norm > 0
+    theta0_full, bounds_full = pack_theta_bounds(start, x, {})
+    dx_med = float(np.median(np.diff(x))) if x.size > 1 else 1.0
+    fwhm_min = max(1e-6, 2.0 * dx_med)
+    theta0, bounds, x_scale, indices = modern._to_solver_vectors(theta0_full, bounds_full, start, fwhm_min)
+    weights = noise_weights(y, "none")
+    resid_jac = build_residual_jac(x, y, start, "add", None, weights)
+    def fun(t):
+        return resid_jac(t)[0]
+    def jac(t):
+        return resid_jac(t)[1]
+    ref = least_squares(fun, theta0, jac=jac, method="trf", loss="linear", f_scale=1.0, bounds=bounds, x_scale=x_scale, max_nfev=2)
+    theta_ref = theta0_full.copy()
+    theta_ref[indices] = ref.x
+    assert np.allclose(theta_step, theta_ref, rtol=1e-6)
+    assert np.isfinite(res.cost1)
+
+
+def test_vp_step_parity():
+    x, y, start = _problem()
+    payload = {"x": x, "y": y, "peaks": start, "mode": "add", "baseline": None, "options": {}}
+    theta_step, res = modern_vp_step(payload)
+    assert res.accepted and res.cost1 < res.cost0 and res.step_norm > 0
+    ref = modern_vp.solve(x, y, [Peak(p.center, p.height, p.fwhm, p.eta) for p in start], "add", None, {"maxfev": 1})
+    assert np.allclose(theta_step, ref["theta"], rtol=1e-6)
+    assert np.isfinite(res.cost1)
+
+
+def test_lmfit_step_parity():
+    try:
+        import lmfit  # noqa: F401
+    except Exception:
+        pytest.skip("lmfit not installed")
+    x, y, start = _problem()
+    payload = {"x": x, "y": y, "peaks": start, "mode": "add", "baseline": None, "options": {}}
+    theta_step, res = lmfit_step(payload)
+    assert res.accepted and res.cost1 < res.cost0 and res.step_norm > 0
+    ref = lmfit_backend.solve(x, y, [Peak(p.center, p.height, p.fwhm, p.eta) for p in start], "add", None, {"maxfev": 1})
+    assert np.allclose(theta_step, ref["theta"], rtol=1e-6)
+    assert np.isfinite(res.cost1)


### PR DESCRIPTION
## Summary
- add solver-specific Step adapters for classic, TRF, VP and lmfit solvers
- wire GUI Step ▶ to call solver-specific adapters and report diagnostics
- add parity tests to ensure Step matches one-iteration behaviour for each solver

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af89841ddc833092c760f9034c717c