### PR TITLE
Normalize uncertainty outputs and exports

### DIFF
--- a/core/data_io.py
+++ b/core/data_io.py
@@ -5,7 +5,7 @@ artifacts. Implementations follow the Peakfit 3.x blueprint.
 """
 from __future__ import annotations
 
-from typing import Iterable, Tuple
+from typing import Dict, Iterable, Tuple, Union
 
 import csv
 import io
@@ -14,6 +14,8 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+
+from .uncertainty import UncertaintyResult
 
 
 def load_xy(path: str) -> Tuple[np.ndarray, np.ndarray]:
@@ -198,52 +200,61 @@ def write_dataframe(df: pd.DataFrame, path: Path) -> None:
         df.to_csv(fh, index=False, lineterminator="\n")
 
 
-def write_uncertainty_csv(path: Path, unc: dict) -> None:
+def _ensure_result(unc: Union[UncertaintyResult, dict]) -> UncertaintyResult:
+    if isinstance(unc, UncertaintyResult):
+        return unc
+    # minimal adapter from legacy dicts
+    params: Dict[str, Dict[str, float]] = {}
+    for name, stats in unc.get("params", {}).items():
+        params[name] = {
+            "est": stats.get("mean"),
+            "sd": stats.get("std"),
+        }
+        if stats.get("q05") is not None and stats.get("q95") is not None:
+            params[name]["p2.5"] = stats.get("q05")
+            params[name]["p97.5"] = stats.get("q95")
+    band = None
+    if unc.get("band"):
+        b = unc["band"]
+        band = (np.asarray(b["x"]), np.asarray(b["lo"]), np.asarray(b["hi"]))
+    meta = {
+        "ess": unc.get("diagnostics", {}).get("ess"),
+        "rhat": unc.get("diagnostics", {}).get("rhat"),
+    }
+    return UncertaintyResult(str(unc.get("method", "unknown")), band, params, meta)
+
+
+def write_uncertainty_csv(path: Path, unc: Union[UncertaintyResult, dict]) -> None:
     """Write uncertainty statistics to ``path``.
 
-    The CSV schema is: ``param, mean, std, q05, q50, q95, method, ess, rhat``.
-    Global diagnostics (``ess``/``rhat``) are repeated on every row for ease of
-    inspection.
+    The CSV schema is a single-row table with per-parameter columns like
+    ``p0_est``, ``p0_sd`` and optional ``p0_p2_5``/``p0_p97_5``.
     """
 
-    rows = []
-    diag = unc.get("diagnostics", {})
-    ess = diag.get("ess")
-    rhat = diag.get("rhat")
-    for name, stats in unc.get("params", {}).items():
-        rows.append(
-            {
-                "param": name,
-                "mean": stats.get("mean"),
-                "std": stats.get("std"),
-                "q05": stats.get("q05"),
-                "q50": stats.get("q50"),
-                "q95": stats.get("q95"),
-                "method": unc.get("method"),
-                "ess": ess,
-                "rhat": rhat,
-            }
-        )
-    df = pd.DataFrame(rows, columns=["param", "mean", "std", "q05", "q50", "q95", "method", "ess", "rhat"])
+    res = _ensure_result(unc)
+    row: Dict[str, float | str] = {"method": res.method_label}
+    for name, stats in res.param_stats.items():
+        row[f"{name}_est"] = stats.get("est")
+        row[f"{name}_sd"] = stats.get("sd")
+        if "p2.5" in stats and "p97.5" in stats:
+            row[f"{name}_p2_5"] = stats.get("p2.5")
+            row[f"{name}_p97_5"] = stats.get("p97.5")
+    df = pd.DataFrame([row])
     write_dataframe(df, path)
 
 
-def write_uncertainty_txt(path: Path, unc: dict) -> None:
+def write_uncertainty_txt(path: Path, unc: Union[UncertaintyResult, dict]) -> None:
     """Write a human readable uncertainty summary to ``path``."""
 
-    lines = [f"Method: {unc.get('method', 'unknown').capitalize()}"]
-    params = unc.get("params", {})
-    for name, stats in params.items():
-        mean = stats.get("mean")
-        std = stats.get("std")
-        lo = stats.get("q05")
-        hi = stats.get("q95")
-        lines.append(f"{name} = {mean:.6g} ± {std:.6g} (95% CI: [{lo:.6g}, {hi:.6g}])")
-    diag = unc.get("diagnostics", {})
-    if diag.get("ess") is not None:
-        lines.append(f"ESS ≈ {diag['ess']:.1f}")
-    if diag.get("rhat") is not None:
-        lines.append(f"R-hat ≈ {diag['rhat']:.3f}")
+    res = _ensure_result(unc)
+    lines = [f"Method: {res.method_label}"]
+    for name, stats in res.param_stats.items():
+        est = stats.get("est")
+        sd = stats.get("sd")
+        line = f"{name}: {est:.6g} ± {sd:.6g}"
+        if "p2.5" in stats and "p97.5" in stats:
+            line += f"   [2.5%: {stats['p2.5']:.6g}, 97.5%: {stats['p97.5']:.6g}]"
+        lines.append(line)
     text = "\n".join(lines) + "\n"
     path.write_text(text, encoding="utf-8")
 

--- a/tests/test_bayesian_basic.py
+++ b/tests/test_bayesian_basic.py
@@ -30,4 +30,5 @@ def test_bayesian_basic(two_peak_data, tmp_path):
     text = paths["unc_txt"].read_text(encoding="utf-8")
     assert "±" in text
     df2 = pd.read_csv(paths["unc_csv"])
-    assert set(df2.columns) == {"param", "mean", "std", "q05", "q50", "q95", "method", "ess", "rhat"}
+    for pname in res.param_stats.keys():
+        assert f"{pname}_sd" in df2.columns

--- a/tests/test_bayesian_optional.py
+++ b/tests/test_bayesian_optional.py
@@ -1,18 +1,15 @@
 from core import fit_api, uncertainty, data_io
+import pytest
 
 
 def test_bayesian_optional(two_peak_data, tmp_path):
+    pytest.importorskip("emcee")
     fit = fit_api.run_fit_consistent(
         **two_peak_data, return_jacobian=True, return_predictors=True
     )
     res = uncertainty.bayesian_ci(fit, n_steps=20, n_burn=10, n_walkers=8, seed=1)
     paths = data_io.derive_export_paths(str(tmp_path / "out.csv"))
-    if res.get("method") == "NotAvailable":
-        data_io.write_uncertainty_txt(paths["unc_txt"], {"method": "NotAvailable", "params": {}, "diagnostics": {}})
-        text = paths["unc_txt"].read_text(encoding="utf-8")
-        assert "not" in text.lower()
-    else:
-        data_io.write_uncertainty_csv(paths["unc_csv"], res)
-        data_io.write_uncertainty_txt(paths["unc_txt"], res)
-        text = paths["unc_txt"].read_text(encoding="utf-8")
-        assert "±" in text
+    data_io.write_uncertainty_csv(paths["unc_csv"], res)
+    data_io.write_uncertainty_txt(paths["unc_txt"], res)
+    text = paths["unc_txt"].read_text(encoding="utf-8")
+    assert "±" in text

--- a/tests/test_export_filenames_and_noblanks.py
+++ b/tests/test_export_filenames_and_noblanks.py
@@ -26,6 +26,7 @@ def test_export_filenames_and_noblanks(two_peak_data, tmp_path, no_blank_lines):
         assert no_blank_lines(paths[key])
 
     df = pd.read_csv(paths["unc_csv"])
-    assert list(df.columns) == ["param", "mean", "std", "q05", "q50", "q95", "method", "ess", "rhat"]
+    for pname in unc.param_stats.keys():
+        assert f"{pname}_sd" in df.columns
     text = paths["unc_txt"].read_text(encoding="utf-8")
-    assert "±" in text and "CI" in text
+    assert "±" in text

--- a/tests/test_unc_bootstrap_outputs.py
+++ b/tests/test_unc_bootstrap_outputs.py
@@ -1,17 +1,28 @@
 import numpy as np
-from core import fit_api, uncertainty
+import pandas as pd
+from core import fit_api, uncertainty, data_io
 
 
-def test_unc_bootstrap_outputs(two_peak_data):
+def test_unc_bootstrap_outputs(two_peak_data, tmp_path):
     fit = fit_api.run_fit_consistent(
         **two_peak_data, return_jacobian=True, return_predictors=True
     )
-    res1 = uncertainty.bootstrap_ci(fit, n_boot=200, seed=42, workers=0)
-    stats = res1["param_stats"]
-    assert np.any(stats["std"] > 0)
-    band = res1["band"]
-    x, lo, hi = band["x"], band["lo"], band["hi"]
-    assert len(x) == len(lo) == len(hi)
-    res2 = uncertainty.bootstrap_ci(fit, n_boot=200, seed=42, workers=0)
+    res1 = uncertainty.bootstrap_ci(fit, n_boot=20, seed=42, workers=0)
+    assert res1.method_label == "Bootstrap"
+
+    paths = data_io.derive_export_paths(str(tmp_path / "out.csv"))
+    data_io.write_uncertainty_csv(paths["unc_csv"], res1)
+    df = pd.read_csv(paths["unc_csv"])
+    for pname in res1.param_stats.keys():
+        sd_col = f"{pname}_sd"
+        assert sd_col in df.columns
+        assert np.isfinite(df.loc[0, sd_col])
+        p_lo = f"{pname}_p2_5"
+        p_hi = f"{pname}_p97_5"
+        if p_lo in df.columns and p_hi in df.columns:
+            est = df.loc[0, f"{pname}_est"]
+            assert df.loc[0, p_lo] - 1e-9 <= est <= df.loc[0, p_hi] + 1e-9
+
+    res2 = uncertainty.bootstrap_ci(fit, n_boot=20, seed=42, workers=0)
     assert np.allclose(res1["param_mean"], res2["param_mean"])
     assert np.allclose(res1["param_std"], res2["param_std"])

--- a/tests/test_uncertainty_txt_plusminus.py
+++ b/tests/test_uncertainty_txt_plusminus.py
@@ -33,9 +33,12 @@ def test_uncertainty_txt_plusminus(tmp_path):
     data_io.write_uncertainty_txt(paths["unc_txt"], unc)
 
     text = paths["unc_txt"].read_text(encoding="utf-8")
+    assert any(m in text for m in ("Asymptotic", "Bootstrap", "Bayesian"))
     for pname in ("p0", "p1", "p2", "p3"):
-        assert f"{pname} =" in text and "±" in text
+        assert f"{pname}:" in text and "±" in text
 
     df2 = pd.read_csv(paths["unc_csv"])
-    assert set(df2.columns) == {"param", "mean", "std", "q05", "q50", "q95", "method", "ess", "rhat"}
+    for pname in ("p0", "p1", "p2", "p3"):
+        assert f"{pname}_sd" in df2.columns
+        assert np.isfinite(df2.loc[0, f"{pname}_sd"])
 


### PR DESCRIPTION
## Summary
- Standardize uncertainty results with a new `UncertaintyResult` dataclass and expose method labels
- Return `UncertaintyResult` from asymptotic, bootstrap, and Bayesian engines and fill parameter stats/bands
- Export uncertainty stats with per-parameter columns and `± sd` text reports; log method details in GUI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af9356631c83308311b7fb9c1a817e