### PR TITLE
Normalize uncertainty outputs and exports

### DIFF
--- a/tests/test_bayesian_basic.py
+++ b/tests/test_bayesian_basic.py
@@ -30,4 +30,5 @@ def test_bayesian_basic(two_peak_data, tmp_path):
     text = paths["unc_txt"].read_text(encoding="utf-8")
     assert "±" in text
     df2 = pd.read_csv(paths["unc_csv"])
-    assert set(df2.columns) == {"param", "mean", "std", "q05", "q50", "q95", "method", "ess", "rhat"}
+    for pname in res.params.keys():
+        assert f"{pname}_sd" in df2.columns

--- a/tests/test_bayesian_optional.py
+++ b/tests/test_bayesian_optional.py
@@ -1,18 +1,15 @@
 from core import fit_api, uncertainty, data_io
+import pytest
 
 
 def test_bayesian_optional(two_peak_data, tmp_path):
+    pytest.importorskip("emcee")
     fit = fit_api.run_fit_consistent(
         **two_peak_data, return_jacobian=True, return_predictors=True
     )
     res = uncertainty.bayesian_ci(fit, n_steps=20, n_burn=10, n_walkers=8, seed=1)
     paths = data_io.derive_export_paths(str(tmp_path / "out.csv"))
-    if res.get("method") == "NotAvailable":
-        data_io.write_uncertainty_txt(paths["unc_txt"], {"method": "NotAvailable", "params": {}, "diagnostics": {}})
-        text = paths["unc_txt"].read_text(encoding="utf-8")
-        assert "not" in text.lower()
-    else:
-        data_io.write_uncertainty_csv(paths["unc_csv"], res)
-        data_io.write_uncertainty_txt(paths["unc_txt"], res)
-        text = paths["unc_txt"].read_text(encoding="utf-8")
-        assert "±" in text
+    data_io.write_uncertainty_csv(paths["unc_csv"], res)
+    data_io.write_uncertainty_txt(paths["unc_txt"], res)
+    text = paths["unc_txt"].read_text(encoding="utf-8")
+    assert "±" in text

--- a/tests/test_export_filenames_and_noblanks.py
+++ b/tests/test_export_filenames_and_noblanks.py
@@ -26,6 +26,7 @@ def test_export_filenames_and_noblanks(two_peak_data, tmp_path, no_blank_lines):
         assert no_blank_lines(paths[key])
 
     df = pd.read_csv(paths["unc_csv"])
-    assert list(df.columns) == ["param", "mean", "std", "q05", "q50", "q95", "method", "ess", "rhat"]
+    for pname in unc.params.keys():
+        assert f"{pname}_sd" in df.columns
     text = paths["unc_txt"].read_text(encoding="utf-8")
-    assert "±" in text and "CI" in text
+    assert "±" in text

--- a/tests/test_seeded_determinism.py
+++ b/tests/test_seeded_determinism.py
@@ -3,17 +3,23 @@ import pandas as pd
 import hashlib
 import numpy as np
 from core import fit_api, uncertainty, data_io
+from core.uncertainty import UncertaintyResult
 
 
 def _export(path_base, theta, std):
     paths = data_io.derive_export_paths(str(path_base))
     df_fit = pd.DataFrame({"theta": theta})
     data_io.write_dataframe(df_fit, paths["fit"])
-    unc = {
-        "method": "asymptotic",
-        "params": {f"p{i}": {"mean": float(theta[i]), "std": float(std[i]), "q05": float(theta[i]-1.96*std[i]), "q50": float(theta[i]), "q95": float(theta[i]+1.96*std[i])} for i in range(len(theta))},
-        "diagnostics": {"ess": None, "rhat": None, "n_samples": None},
+    params = {
+        f"p{i}": {
+            "est": float(theta[i]),
+            "sd": float(std[i]),
+            "p2_5": float(theta[i] - 1.96 * std[i]),
+            "p97_5": float(theta[i] + 1.96 * std[i]),
+        }
+        for i in range(len(theta))
     }
+    unc = UncertaintyResult("asymptotic", "Asymptotic (JᵀJ)", params)
     data_io.write_uncertainty_csv(paths["unc_csv"], unc)
     return (
         hashlib.md5(paths["fit"].read_bytes()).hexdigest(),
@@ -47,8 +53,10 @@ def test_seeded_determinism(two_peak_data, tmp_path, no_blank_lines):
     fit = fit_api.run_fit_consistent(
         **two_peak_data, return_jacobian=True, return_predictors=True
     )
-    b1 = uncertainty.bayesian_ci(fit, seed=123, n_steps=20, n_burn=10, n_walkers=8)
-    b2 = uncertainty.bayesian_ci(fit, seed=123, n_steps=20, n_burn=10, n_walkers=8)
-    if b1.get("method") != "NotAvailable":
-        assert np.allclose(b1["param_mean"], b2["param_mean"])
-        assert np.allclose(b1["param_std"], b2["param_std"])
+    try:
+        b1 = uncertainty.bayesian_ci(fit, seed=123, n_steps=20, n_burn=10, n_walkers=8)
+        b2 = uncertainty.bayesian_ci(fit, seed=123, n_steps=20, n_burn=10, n_walkers=8)
+    except ImportError:
+        return
+    assert np.allclose(b1["param_mean"], b2["param_mean"])
+    assert np.allclose(b1["param_std"], b2["param_std"])

--- a/tests/test_unc_bootstrap_outputs.py
+++ b/tests/test_unc_bootstrap_outputs.py
@@ -1,17 +1,29 @@
 import numpy as np
-from core import fit_api, uncertainty
+import pandas as pd
+from core import fit_api, uncertainty, data_io
 
 
-def test_unc_bootstrap_outputs(two_peak_data):
+def test_unc_bootstrap_outputs(two_peak_data, tmp_path):
     fit = fit_api.run_fit_consistent(
         **two_peak_data, return_jacobian=True, return_predictors=True
     )
-    res1 = uncertainty.bootstrap_ci(fit, n_boot=200, seed=42, workers=0)
-    stats = res1["param_stats"]
-    assert np.any(stats["std"] > 0)
-    band = res1["band"]
-    x, lo, hi = band["x"], band["lo"], band["hi"]
-    assert len(x) == len(lo) == len(hi)
-    res2 = uncertainty.bootstrap_ci(fit, n_boot=200, seed=42, workers=0)
+    res1 = uncertainty.bootstrap_ci(fit, n_boot=20, seed=42, workers=0)
+    assert res1.method_label == "Bootstrap (residual)"
+
+    paths = data_io.derive_export_paths(str(tmp_path / "out.csv"))
+    data_io.write_uncertainty_csv(paths["unc_csv"], res1)
+    df = pd.read_csv(paths["unc_csv"])
+    for pname in res1.params.keys():
+        sd_col = f"{pname}_sd"
+        assert sd_col in df.columns
+        assert np.isfinite(df.loc[0, sd_col])
+        p_lo = f"{pname}_p2_5"
+        p_hi = f"{pname}_p97_5"
+        assert p_lo in df.columns and p_hi in df.columns
+        est = df.loc[0, f"{pname}_est"]
+        if np.isfinite(df.loc[0, p_lo]) and np.isfinite(df.loc[0, p_hi]):
+            assert df.loc[0, p_lo] - 1e-9 <= est <= df.loc[0, p_hi] + 1e-9
+
+    res2 = uncertainty.bootstrap_ci(fit, n_boot=20, seed=42, workers=0)
     assert np.allclose(res1["param_mean"], res2["param_mean"])
     assert np.allclose(res1["param_std"], res2["param_std"])

--- a/tests/test_uncertainty_txt_plusminus.py
+++ b/tests/test_uncertainty_txt_plusminus.py
@@ -33,9 +33,12 @@ def test_uncertainty_txt_plusminus(tmp_path):
     data_io.write_uncertainty_txt(paths["unc_txt"], unc)
 
     text = paths["unc_txt"].read_text(encoding="utf-8")
+    assert any(m in text for m in ("Asymptotic", "Bootstrap", "Bayesian"))
     for pname in ("p0", "p1", "p2", "p3"):
-        assert f"{pname} =" in text and "±" in text
+        assert f"{pname}:" in text and "±" in text
 
     df2 = pd.read_csv(paths["unc_csv"])
-    assert set(df2.columns) == {"param", "mean", "std", "q05", "q50", "q95", "method", "ess", "rhat"}
+    for pname in ("p0", "p1", "p2", "p3"):
+        assert f"{pname}_sd" in df2.columns
+        assert np.isfinite(df2.loc[0, f"{pname}_sd"])
 


### PR DESCRIPTION
## Summary
- Replace ad-hoc uncertainty dicts with an `UncertaintyResult` dataclass including method labels, parameter stats and diagnostics
- Emit uncertainty text and CSV exports with `est`, `sd`, and optional `p2_5`/`p97_5` columns in fixed order
- Update GUI uncertainty runner to dispatch by method, surface readable labels, and show bands when returned

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af9356631c83308311b7fb9c1a817e