### PR TITLE
Improve uncertainty handling in GUI

### DIFF
--- a/tests/test_unc_label_bridge.py
+++ b/tests/test_unc_label_bridge.py
@@ -1,0 +1,18 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from core import data_io  # noqa: E402
+
+
+def test_bridge_bootstrap_and_bayesian():
+    boot = {"type": "bootstrap", "params": {"h1": {"est": 1.0, "sd": 0.2}}}
+    res = data_io._ensure_result(boot)
+    assert res.method == "bootstrap"
+    assert res.method_label == "Bootstrap (residual)"
+
+    bayes = {"type": "bayesian", "params": {"h1": {"est": 1.0, "sd": 0.2}}}
+    res2 = data_io._ensure_result(bayes)
+    assert res2.method == "bayesian"
+    assert res2.method_label == "Bayesian (MCMC)"
+

--- a/tests/test_unc_text_includes_label.py
+++ b/tests/test_unc_text_includes_label.py
@@ -1,0 +1,15 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from core import data_io  # noqa: E402
+
+
+def test_unc_text_includes_label_and_pm(tmp_path):
+    res_dict = {"type": "bootstrap", "params": {"p1": {"est": 1.0, "sd": 0.2}}}
+    path = tmp_path / "unc.txt"
+    data_io.write_uncertainty_txt(path, res_dict)
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert "Bootstrap (residual)" in lines[0]
+    assert "±" in lines[1]
+


### PR DESCRIPTION
## Summary
- Add robust status and progress helpers with logging fallbacks
- Track and deduplicate uncertainty jobs while extracting labels and bands
- Show per-peak uncertainty stats and stop the spinner after completion

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afc128c8d48330adc887f33e136865