### PR TITLE
Improve uncertainty handling in GUI

### DIFF
--- a/core/data_io.py
+++ b/core/data_io.py
@@ -203,25 +203,51 @@ def write_dataframe(df: pd.DataFrame, path: Path) -> None:
 def _ensure_result(unc: Union[UncertaintyResult, dict]) -> UncertaintyResult:
     if isinstance(unc, UncertaintyResult):
         return unc
-    # minimal adapter from legacy dicts
+
+    method = str(unc.get("method") or unc.get("type") or "unknown").lower()
+    if method == "asymptotic":
+        method_label = "Asymptotic (JᵀJ)"
+    elif method == "bootstrap":
+        method_label = "Bootstrap (residual)"
+    elif method == "bayesian":
+        method_label = "Bayesian (MCMC)"
+    else:
+        method_label = "unknown"
+
     params: Dict[str, Dict[str, float]] = {}
     for name, stats in unc.get("params", {}).items():
-        params[name] = {
-            "est": stats.get("mean"),
-            "sd": stats.get("std"),
-        }
-        if stats.get("q05") is not None and stats.get("q95") is not None:
-            params[name]["p2.5"] = stats.get("q05")
-            params[name]["p97.5"] = stats.get("q95")
+        est = stats.get("est") or stats.get("mean") or stats.get("median")
+        sd = stats.get("sd") or stats.get("stderr") or stats.get("sigma")
+        p2 = stats.get("p2.5") or stats.get("p2_5") or stats.get("q05")
+        p97 = stats.get("p97.5") or stats.get("p97_5") or stats.get("q95")
+        params[name] = {"est": est, "sd": sd}
+        if p2 is not None and p97 is not None:
+            params[name]["p2.5"] = p2
+            params[name]["p97.5"] = p97
+
     band = None
-    if unc.get("band"):
-        b = unc["band"]
-        band = (np.asarray(b["x"]), np.asarray(b["lo"]), np.asarray(b["hi"]))
-    meta = {
+    b = unc.get("band") or unc.get("curve_band")
+    if b:
+        if isinstance(b, dict):
+            band = (
+                np.asarray(b.get("x")),
+                np.asarray(b.get("lo")),
+                np.asarray(b.get("hi")),
+            )
+        elif isinstance(b, (tuple, list)) and len(b) == 3:
+            band = tuple(np.asarray(part) for part in b)
+
+    diagnostics = {
         "ess": unc.get("diagnostics", {}).get("ess"),
         "rhat": unc.get("diagnostics", {}).get("rhat"),
     }
-    return UncertaintyResult(str(unc.get("method", "unknown")), band, params, meta)
+    return UncertaintyResult(
+        method=method,
+        label=method_label,
+        stats=params,
+        diagnostics=diagnostics,
+        band=band,
+    )
 
 
 def write_uncertainty_csv(path: Path, unc: Union[UncertaintyResult, dict]) -> None:

--- a/tests/test_seeded_determinism.py
+++ b/tests/test_seeded_determinism.py
@@ -19,7 +19,13 @@ def _export(path_base, theta, std):
         }
         for i in range(len(theta))
     }
-    unc = UncertaintyResult("asymptotic", None, param_stats, {})
+    unc = UncertaintyResult(
+        method="asymptotic",
+        label="Asymptotic (JᵀJ)",
+        stats=param_stats,
+        diagnostics={},
+        band=None,
+    )
     data_io.write_uncertainty_csv(paths["unc_csv"], unc)
     return (
         hashlib.md5(paths["fit"].read_bytes()).hexdigest(),

--- a/tests/test_unc_bootstrap_outputs.py
+++ b/tests/test_unc_bootstrap_outputs.py
@@ -8,7 +8,7 @@ def test_unc_bootstrap_outputs(two_peak_data, tmp_path):
         **two_peak_data, return_jacobian=True, return_predictors=True
     )
     res1 = uncertainty.bootstrap_ci(fit, n_boot=20, seed=42, workers=0)
-    assert res1.method_label == "Bootstrap"
+    assert res1.method_label == "Bootstrap (residual)"
 
     paths = data_io.derive_export_paths(str(tmp_path / "out.csv"))
     data_io.write_uncertainty_csv(paths["unc_csv"], res1)

--- a/tests/test_unc_label_bridge.py
+++ b/tests/test_unc_label_bridge.py
@@ -1,0 +1,18 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from core import data_io  # noqa: E402
+
+
+def test_bridge_bootstrap_and_bayesian():
+    boot = {"type": "bootstrap", "params": {"h1": {"est": 1.0, "sd": 0.2}}}
+    res = data_io._ensure_result(boot)
+    assert res.method == "bootstrap"
+    assert res.method_label == "Bootstrap (residual)"
+
+    bayes = {"type": "bayesian", "params": {"h1": {"est": 1.0, "sd": 0.2}}}
+    res2 = data_io._ensure_result(bayes)
+    assert res2.method == "bayesian"
+    assert res2.method_label == "Bayesian (MCMC)"
+

--- a/tests/test_unc_text_includes_label.py
+++ b/tests/test_unc_text_includes_label.py
@@ -1,0 +1,15 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from core import data_io  # noqa: E402
+
+
+def test_unc_text_includes_label_and_pm(tmp_path):
+    res_dict = {"type": "bootstrap", "params": {"p1": {"est": 1.0, "sd": 0.2}}}
+    path = tmp_path / "unc.txt"
+    data_io.write_uncertainty_txt(path, res_dict)
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert "Bootstrap (residual)" in lines[0]
+    assert "±" in lines[1]
+

--- a/ui/app.py
+++ b/ui/app.py
@@ -186,7 +186,7 @@ import time
 import csv
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, Dict, Iterable, List, Tuple, Optional
 
 import numpy as np
 
@@ -687,6 +687,11 @@ class PeakFitApp:
         self._update_template_info()
         self.apply_performance()
 
+        # Uncertainty job tracking / last log
+        self._unc_job_id = 0
+        self._unc_running = False
+        self._last_unc_log = None
+
     # ----- UI -----
     def _build_ui(self):
         top = ttk.Frame(self.root, padding=6)
@@ -1099,11 +1104,13 @@ class PeakFitApp:
         # Status bar and log
         bar = ttk.Frame(self.root); bar.pack(side=tk.BOTTOM, fill=tk.X)
         self.status_var = tk.StringVar(value="Open CSV/TXT/DAT, set baseline/range, add peaks, set η, then Fit.")
-        ttk.Label(bar, textvariable=self.status_var).pack(side=tk.LEFT, padx=6)
+        self.status = ttk.Label(bar, textvariable=self.status_var)
+        self.status.pack(side=tk.LEFT, padx=6)
         self.log_btn = ttk.Button(bar, text="Show log \u25B8", command=self.toggle_log)
         self.log_btn.pack(side=tk.RIGHT)
         self.pbar = ttk.Progressbar(bar, mode="indeterminate", length=160)
         self.pbar.pack(side=tk.RIGHT, padx=6)
+        self.progress = self.pbar
         self._log_console = None
         self._log_visible = False
         self._log_frame = None
@@ -1367,6 +1374,268 @@ class PeakFitApp:
 
     def log_threadsafe(self, msg: str, level: str = "INFO"):
         self.log(msg, level)
+
+    def log_info(self, msg: str) -> None:
+        self.log(msg, "INFO")
+
+    def log_warn(self, msg: str) -> None:
+        self.log(msg, "WARN")
+
+    def log_error(self, msg: str) -> None:
+        self.log(msg, "ERROR")
+
+    # --- Status + progress helpers (UI-safe, no-ops if widgets missing) ---
+    def status_info(self, msg: str) -> None:
+        try:
+            if hasattr(self, "status") and self.status:
+                self.status.config(text=msg)
+            if hasattr(self, "status_var") and self.status_var:
+                self.status_var.set(msg)
+        except Exception:
+            pass
+        cb = getattr(self, "log_info", None)
+        if callable(cb):
+            try:
+                cb(msg)
+                return
+            except Exception:
+                pass
+        print(msg)
+
+    def status_warn(self, msg: str) -> None:
+        try:
+            if hasattr(self, "status") and self.status:
+                self.status.config(text=msg)
+            if hasattr(self, "status_var") and self.status_var:
+                self.status_var.set(msg)
+        except Exception:
+            pass
+        cb = getattr(self, "log_warn", None)
+        if callable(cb):
+            try:
+                cb(msg)
+                return
+            except Exception:
+                pass
+        print("WARN:", msg)
+
+    def status_error(self, msg: str) -> None:
+        try:
+            if hasattr(self, "status") and self.status:
+                self.status.config(text=msg)
+            if hasattr(self, "status_var") and self.status_var:
+                self.status_var.set(msg)
+        except Exception:
+            pass
+        cb = getattr(self, "log_error", None)
+        if callable(cb):
+            try:
+                cb(msg)
+                return
+            except Exception:
+                pass
+        print("ERROR:", msg)
+
+    def _progress_begin(self, tag: str = "task") -> None:
+        # Start progressbar if present; tolerate absence.
+        try:
+            if getattr(self, "_progress_depth", None) is None:
+                self._progress_depth = 0
+            self._progress_depth += 1
+            pb = getattr(self, "progress", None)
+            if pb and hasattr(pb, "start"):
+                # Use a small interval; Tk handles animation.
+                pb.start(10)
+        except Exception:
+            pass
+
+    def _progress_end(self, tag: str = "task") -> None:
+        # Stop progressbar if present; tolerate absence.
+        try:
+            if getattr(self, "_progress_depth", None) is None:
+                self._progress_depth = 0
+            self._progress_depth = max(0, self._progress_depth - 1)
+            if self._progress_depth == 0:
+                pb = getattr(self, "progress", None)
+                if pb and hasattr(pb, "stop"):
+                    pb.stop()
+        except Exception:
+            pass
+
+    def _unc_pretty_label(self, obj) -> str:
+        # Accept UncertaintyResult-like, SimpleNamespace, or dict
+        try:
+            lbl = getattr(obj, "label", None) or getattr(obj, "method_label", None)
+            if not lbl:
+                lbl = getattr(obj, "method", None) or getattr(obj, "type", None)
+        except Exception:
+            lbl = None
+        if not lbl and isinstance(obj, dict):
+            lbl = obj.get("label") or obj.get("method") or obj.get("type")
+        text = (str(lbl) if lbl else "").lower()
+
+        # Map common aliases
+        if "asym" in text or "j" in text and "t" in text and "j" in text:  # covers "jtj", "j^t j"
+            return "Asymptotic (JᵀJ)"
+        if "boot" in text or "resid" in text:
+            return "Bootstrap (residual)"
+        if "bayes" in text or "mcmc" in text:
+            return "Bayesian (MCMC)"
+        # Fallback to original label or generic
+        return str(lbl) if lbl else "Unknown"
+
+    def _unc_extract_band(self, obj):
+        import numpy as np
+        # return (x, lo, hi) or None
+        # Attribute forms
+        for attr in ("band", "prediction_band"):
+            xlh = getattr(obj, attr, None)
+            if xlh:
+                try:
+                    x, lo, hi = xlh
+                    x = np.asarray(x); lo = np.asarray(lo); hi = np.asarray(hi)
+                    if x.shape == lo.shape == hi.shape and x.size > 0:
+                        return (x, lo, hi)
+                except Exception:
+                    pass
+        # Dict forms
+        if isinstance(obj, dict):
+            # Combined
+            if "band" in obj:
+                try:
+                    x, lo, hi = obj["band"]
+                    x = np.asarray(x); lo = np.asarray(lo); hi = np.asarray(hi)
+                    if x.shape == lo.shape == hi.shape and x.size > 0:
+                        return (x, lo, hi)
+                except Exception:
+                    pass
+            # Split keys
+            keys = obj.keys()
+            if {"band_x", "band_lo", "band_hi"} <= set(keys):
+                try:
+                    x = np.asarray(obj["band_x"]); lo = np.asarray(obj["band_lo"]); hi = np.asarray(obj["band_hi"])
+                    if x.shape == lo.shape == hi.shape and x.size > 0:
+                        return (x, lo, hi)
+                except Exception:
+                    pass
+        return None
+
+    def _unc_extract_stats(self, result):
+        """
+        Return list of per-peak dicts with keys:
+          center_est, center_sd, height_est, height_sd, fwhm_est, fwhm_sd
+        Supports:
+          - result.stats / parameters / param_stats
+          - list-of-dicts rows
+          - dict {'center': {'est':[...],'sd':[...]} , ...}
+          - flat dict-of-lists {'center_est':[...], 'height_sd':[...], ...}
+        """
+        import math
+
+        def _pick_idx(container, i, *keys):
+            # pick container[key][i] for first existing key; tolerate short arrays
+            for k in keys:
+                v = container.get(k)
+                if v is None:
+                    continue
+                try:
+                    return v[i]
+                except Exception:
+                    # could be scalar
+                    try:
+                        return v
+                    except Exception:
+                        pass
+            return None
+
+        def _coerce_row(row):
+            # row may be nested: {'center': {'est':..,'sd':..}, 'height': {...}, 'fwhm': {...}}
+            out = {}
+            # nested blocks
+            for pname in ("center", "height", "fwhm"):
+                blk = row.get(pname)
+                if isinstance(blk, dict):
+                    est = blk.get("est") or blk.get("mean") or blk.get("median") or blk.get("value")
+                    sd  = blk.get("sd")  or blk.get("std")  or blk.get("se")
+                    if est is not None: out[f"{pname}_est"] = est
+                    if sd  is not None: out[f"{pname}_sd"]  = sd
+            # flat fallbacks
+            for pname in ("center", "height", "fwhm"):
+                for k in (f"{pname}_est", pname):
+                    if k in row and row[k] is not None:
+                        out.setdefault(f"{pname}_est", row[k])
+                        break
+                for k in (f"{pname}_sd", f"{pname}_std", f"{pname}_se"):
+                    if k in row and row[k] is not None:
+                        out.setdefault(f"{pname}_sd", row[k])
+                        break
+            return out
+
+        # locate stats object
+        stats = None
+        for attr in ("stats", "parameters", "param_stats"):
+            if hasattr(result, attr):
+                stats = getattr(result, attr)
+                break
+        if stats is None and isinstance(result, dict):
+            for k in ("stats", "parameters", "param_stats"):
+                if k in result:
+                    stats = result[k]
+                    break
+        if stats is None:
+            return None
+
+        # case A: list-of-dicts
+        if isinstance(stats, (list, tuple)):
+            rows = []
+            for row in stats:
+                if isinstance(row, dict):
+                    rows.append(_coerce_row(row))
+            return rows if rows else None
+
+        # case B: dict form
+        if isinstance(stats, dict):
+            # B1) block-of-arrays: {'center': {'est':[...],'sd':[...]} , ...}
+            if all(k in stats for k in ("center", "height", "fwhm")) and \
+               all(isinstance(stats[k], dict) for k in ("center", "height", "fwhm")):
+                n = 0
+                for pname in ("center", "height", "fwhm"):
+                    for key in ("est", "mean", "median", "value"):
+                        v = stats[pname].get(key)
+                        if hasattr(v, "__len__"):
+                            n = max(n, len(v))
+                rows = []
+                for i in range(n):
+                    row = {
+                        "center": {"est": _pick_idx(stats["center"], i, "est", "mean", "median", "value"),
+                                   "sd":  _pick_idx(stats["center"], i, "sd", "std", "se")},
+                        "height": {"est": _pick_idx(stats["height"], i, "est", "mean", "median", "value"),
+                                   "sd":  _pick_idx(stats["height"], i, "sd", "std", "se")},
+                        "fwhm":   {"est": _pick_idx(stats["fwhm"],   i, "est", "mean", "median", "value"),
+                                   "sd":  _pick_idx(stats["fwhm"],   i, "sd", "std", "se")},
+                    }
+                    rows.append(_coerce_row(row))
+                return rows
+            # B2) flat dict-of-lists: {'center_est':[...], 'height_sd':[...], ...}
+            # compute max length
+            n = 0
+            for v in stats.values():
+                if hasattr(v, "__len__") and not isinstance(v, (str, bytes)):
+                    n = max(n, len(v))
+            if n == 0:
+                return None
+            rows = []
+            for i in range(n):
+                row = {}
+                for k, v in stats.items():
+                    try:
+                        row[k] = v[i] if hasattr(v, "__getitem__") else v
+                    except Exception:
+                        row[k] = v
+                rows.append(_coerce_row(row))
+            return rows
+
+        return None
 
     def run_in_thread(self, fn, on_done):
         def worker():
@@ -2404,7 +2673,22 @@ class PeakFitApp:
 
         def work():
             if method == "asymptotic":
-                return self._run_asymptotic_uncertainty()
+                res = self._run_asymptotic_uncertainty()
+                if res is None:
+                    return None
+                cov, th, _info = res
+                sigma = self._safe_sqrt_vec(np.diag(np.asarray(cov, float)))
+                param_stats = {
+                    "center": {"est": [p.center for p in self.peaks], "sd": sigma[0::4]},
+                    "fwhm": {"est": [p.fwhm for p in self.peaks], "sd": sigma[2::4]},
+                    "height": {"est": [p.height for p in self.peaks], "sd": sigma[1::4]},
+                }
+                return {
+                    "method": "asymptotic",
+                    "method_label": "Asymptotic (JᵀJ)",
+                    "band": self.ci_band[:3] if self.ci_band else None,
+                    "param_stats": param_stats,
+                }
             if method == "bootstrap":
                 cfg = {
                     "x": x_fit,
@@ -2417,58 +2701,151 @@ class PeakFitApp:
                     "n": 100,
                     "workers": self._resolve_unc_workers(),
                 }
-                return bootstrap.bootstrap(self.bootstrap_solver_choice.get(), cfg, resid_fn)
+                res = bootstrap.bootstrap(self.bootstrap_solver_choice.get(), cfg, resid_fn)
+                if isinstance(res, dict):
+                    cb = res.get("curve_band") or {}
+                    if isinstance(cb, dict) and {"x", "lo", "hi"} <= set(cb.keys()):
+                        res["band"] = (cb.get("x"), cb.get("lo"), cb.get("hi"))
+                    if "params" in res and "param_stats" not in res:
+                        try:
+                            params = res.get("params", {})
+                            th = np.asarray(params.get("theta", []), float)
+                            cov = params.get("cov")
+                            sd = (
+                                np.sqrt(np.diag(np.asarray(cov, float)))
+                                if cov is not None and np.size(cov) > 0
+                                else None
+                            )
+                            samples = params.get("samples")
+                            p_lo = p_hi = None
+                            if samples is not None and np.size(samples) > 0:
+                                samp = np.asarray(samples, float)
+                                p_lo = np.quantile(samp, 0.025, axis=0)
+                                p_hi = np.quantile(samp, 0.975, axis=0)
+
+                            def slice_stats(idx: int) -> Dict[str, Any]:
+                                est = th[idx::4] if th.size else None
+                                sd_i = sd[idx::4] if sd is not None else None
+                                d: Dict[str, Any] = {"est": est, "sd": sd_i}
+                                if p_lo is not None and p_hi is not None:
+                                    d["p2_5"] = p_lo[idx::4]
+                                    d["p97_5"] = p_hi[idx::4]
+                                return d
+
+                            res["param_stats"] = {
+                                "center": slice_stats(0),
+                                "height": slice_stats(1),
+                                "fwhm": slice_stats(2),
+                            }
+                        except Exception:
+                            pass
+                return res
             if method == "bayesian":
                 init = {"x": x_fit, "y": y_fit, "peaks": self.peaks, "mode": mode,
                         "baseline": base_fit, "theta": theta}
-                return bayes.bayesian({}, "gaussian", init, {}, resid_fn)
+                res = bayes.bayesian({}, "gaussian", init, {}, resid_fn)
+                if isinstance(res, dict):
+                    cb = res.get("curve_band") or {}
+                    if isinstance(cb, dict) and {"x", "lo", "hi"} <= set(cb.keys()):
+                        res["band"] = (cb.get("x"), cb.get("lo"), cb.get("hi"))
+                    if "params" in res and "param_stats" not in res:
+                        try:
+                            params = res.get("params", {})
+                            th = np.asarray(params.get("theta", []), float)
+                            cov = params.get("cov")
+                            sd = (
+                                np.sqrt(np.diag(np.asarray(cov, float)))
+                                if cov is not None and np.size(cov) > 0
+                                else None
+                            )
+                            samples = params.get("samples")
+                            p_lo = p_hi = None
+                            if samples is not None and np.size(samples) > 0:
+                                samp = np.asarray(samples, float)
+                                p_lo = np.quantile(samp, 0.025, axis=0)
+                                p_hi = np.quantile(samp, 0.975, axis=0)
+
+                            def slice_stats(idx: int) -> Dict[str, Any]:
+                                est = th[idx::4] if th.size else None
+                                sd_i = sd[idx::4] if sd is not None else None
+                                d: Dict[str, Any] = {"est": est, "sd": sd_i}
+                                if p_lo is not None and p_hi is not None:
+                                    d["p2_5"] = p_lo[idx::4]
+                                    d["p97_5"] = p_hi[idx::4]
+                                return d
+
+                            res["param_stats"] = {
+                                "center": slice_stats(0),
+                                "height": slice_stats(1),
+                                "fwhm": slice_stats(2),
+                            }
+                        except Exception:
+                            pass
+                return res
             raise RuntimeError("Unknown method")
 
-        def done(res, err):
-            if err or res is None:
-                self.set_busy(False, "Uncertainty failed.")
-                if err:
-                    self.log(f"Uncertainty failed: {err}", level="ERROR")
-                    messagebox.showerror("Uncertainty", f"Failed: {err}")
+        def done(result, error):
+            # Drop stale callbacks (auto asymptotic finishing after a newer user-triggered run)
+            if job_id != getattr(self, "_unc_job_id", 0):
+                self._progress_end("uncertainty")
                 return
-            if method == "asymptotic":
-                cov, theta, info = res
-                self.show_ci_band = True
-                self.show_ci_band_var.set(True)
-                self.refresh_plot()
-                lines, warns = self._format_asymptotic_summary(cov, theta, info, self.ci_band)
-                for ln in lines:
-                    self.log(ln)
-                for ln in warns:
-                    self.log(ln, level="WARN")
-            else:
-                if isinstance(res, UncertaintyResult):
-                    if res.band is not None:
-                        self.ci_band = res.band
-                        self.show_ci_band = True
-                    extra = ""
-                    if res.method == "bootstrap":
-                        n = res.meta.get("n_resamples")
-                        seed = res.meta.get("seed")
-                        extra = f" (n={n}, seed={seed})" if n is not None else ""
-                    elif res.method == "bayesian":
-                        n_samples = res.meta.get("n_samples")
-                        n_chains = res.meta.get("n_chains")
-                        ess = res.meta.get("ess") or {}
-                        rhat = res.meta.get("rhat") or {}
-                        if ess and rhat:
-                            extra = (
-                                f" (draws={n_samples}, chains={n_chains}; min ESS={min(ess.values()):.0f}, "
-                                f"max R̂={max(rhat.values()):.3f})"
-                            )
-                    msg = f"Computed {res.method_label} uncertainty{extra}"
-                else:
-                    msg = "Bayesian MCMC requires emcee. Skipping." if res is None else f"Computed {getattr(res, 'method', 'unknown')} uncertainty."
-                self.log(msg)
-                messagebox.showinfo("Uncertainty", msg)
-            self.set_busy(False, "Uncertainty ready (95% band).")
 
-        self.set_busy(True, "Computing uncertainty…")
+            self._unc_running = False
+            self._progress_end("uncertainty")
+
+            if error is not None:
+                self.status_error(f"Uncertainty failed: {error}")
+                return
+
+            label = self._unc_pretty_label(result)
+
+            # De-dupe “Computed …” for this job+label
+            if getattr(self, "_last_unc_log", None) == (job_id, label):
+                return
+            self._last_unc_log = (job_id, label)
+
+            # Band
+            band = self._unc_extract_band(result)
+            if band is not None:
+                self.ci_band = band            # store as (x, lo, hi)
+                self.show_ci_band = True
+                try:
+                    self.refresh_plot()
+                except Exception:
+                    pass
+                self.status_info(f"Computed {label} uncertainty.")
+            else:
+                self.status_info(f"Computed {label} uncertainty. (no band)")
+
+            # Per-peak stats
+            try:
+                rows = self._unc_extract_stats(result)
+                if rows:
+                    for i, row in enumerate(rows, 1):
+                        def _fmt(v_est, v_sd):
+                            try:
+                                s_est = f"{float(v_est):.6g}" if v_est is not None else "n/a"
+                            except Exception:
+                                s_est = "n/a"
+                            try:
+                                s_sd = f"{float(v_sd):.3g}" if v_sd is not None else "n/a"
+                            except Exception:
+                                s_sd = "n/a"
+                            return s_est, s_sd
+                        c_est, c_sd = _fmt(row.get("center_est"), row.get("center_sd"))
+                        h_est, h_sd = _fmt(row.get("height_est"), row.get("height_sd"))
+                        w_est, w_sd = _fmt(row.get("fwhm_est"),  row.get("fwhm_sd"))
+                        self.status_info(
+                            f"Peak {i}: center={c_est} ± {c_sd} | height={h_est} ± {h_sd} | FWHM={w_est} ± {w_sd}"
+                        )
+            except Exception as _e:
+                self.status_warn(f"Uncertainty stats formatting skipped ({_e.__class__.__name__}).")
+
+        self._unc_running = True
+        self._unc_job_id += 1
+        job_id = self._unc_job_id
+        self._progress_begin("uncertainty")
+        self.status_info("Computing uncertainty…")
         self.run_in_thread(work, done)
 
     def apply_performance(self):
@@ -2776,9 +3153,20 @@ class PeakFitApp:
             lo, hi = sorted((self.fit_xmin, self.fit_xmax))
             self.ax.axvspan(lo, hi, color="0.8", alpha=0.25, lw=0)
 
-        if self.show_ci_band and self.ci_band is not None:
-            xb, lob, hib, _ = self.ci_band
-            self.ax.fill_between(xb, lob, hib, alpha=0.18, label="Uncertainty band")
+        if getattr(self, "show_ci_band", False) and getattr(self, "ci_band", None) is not None:
+            try:
+                # Accept (x, lo, hi) or (x, lo, hi, method)
+                if len(self.ci_band) == 3:
+                    xb, lob, hib = self.ci_band
+                elif len(self.ci_band) >= 3:
+                    xb, lob, hib = self.ci_band[0], self.ci_band[1], self.ci_band[2]
+                else:
+                    xb = lob = hib = None
+                if xb is not None and lob is not None and hib is not None:
+                    self.ax.fill_between(xb, lob, hib, alpha=0.18, label="Uncertainty band")
+            except Exception:
+                # be robust: never crash plot
+                pass
 
         # Legend toggle
         leg = self.ax.get_legend()


### PR DESCRIPTION
## Summary
- Add robust helpers to prettify labels, extract bands, and normalize uncertainty stats
- Track job IDs in `run_uncertainty` to stop stale callbacks, dedupe logs, and render bands with per‑peak values
- Allow `refresh_plot` to overlay uncertainty bands from 3- or 4-tuple data
- Provide prediction bands from bootstrap and Bayesian uncertainty results and normalize legacy dict outputs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68afc128c8d48330adc887f33e136865