### PR TITLE
feat: add manual uncertainty handling

### DIFF
--- a/core/data_io.py
+++ b/core/data_io.py
@@ -200,6 +200,45 @@ def write_dataframe(df: pd.DataFrame, path: Path) -> None:
         df.to_csv(fh, index=False, lineterminator="\n")
 
 
+def _normalize_band(result):
+    """Return ``(x, lo, hi)`` arrays or ``None``.
+
+    Accepts ``UncertaintyResult`` instances or dict-like structures containing a
+    band description. The function avoids evaluating numpy arrays in boolean
+    context and validates shapes before returning normalized arrays.
+    """
+
+    if result is None:
+        return None
+
+    band = getattr(result, "band", None)
+    if band is None:
+        band = getattr(result, "prediction_band", None)
+
+    if band is None and isinstance(result, dict):
+        band = result.get("band")
+        if band is None:
+            band = result.get("prediction_band")
+        if band is None:
+            band = result.get("ci_band")
+
+    if band is None:
+        return None
+
+    try:
+        if len(band) < 3:
+            return None
+        x, lo, hi = band[0], band[1], band[2]
+        x = np.asarray(x)
+        lo = np.asarray(lo)
+        hi = np.asarray(hi)
+        if x.shape != lo.shape or x.shape != hi.shape or x.size == 0:
+            return None
+        return x, lo, hi
+    except Exception:
+        return None
+
+
 class _DictResult(UncertaintyResult):
     """Shim exposing custom method labels for legacy dict results."""
 
@@ -235,26 +274,32 @@ def _ensure_result(unc: Union[UncertaintyResult, dict]) -> UncertaintyResult:
 
     params: Dict[str, Dict[str, float]] = {}
     for name, stats in unc.get("params", {}).items():
-        est = stats.get("est") or stats.get("mean") or stats.get("median")
-        sd = stats.get("sd") or stats.get("stderr") or stats.get("sigma")
-        p2 = stats.get("p2.5") or stats.get("p2_5") or stats.get("q05")
-        p97 = stats.get("p97.5") or stats.get("p97_5") or stats.get("q95")
+        est = stats.get("est")
+        if est is None:
+            est = stats.get("mean")
+        if est is None:
+            est = stats.get("median")
+        sd = stats.get("sd")
+        if sd is None:
+            sd = stats.get("stderr")
+        if sd is None:
+            sd = stats.get("sigma")
+        p2 = stats.get("p2.5")
+        if p2 is None:
+            p2 = stats.get("p2_5")
+        if p2 is None:
+            p2 = stats.get("q05")
+        p97 = stats.get("p97.5")
+        if p97 is None:
+            p97 = stats.get("p97_5")
+        if p97 is None:
+            p97 = stats.get("q95")
         params[name] = {"est": est, "sd": sd}
         if p2 is not None and p97 is not None:
             params[name]["p2.5"] = p2
             params[name]["p97.5"] = p97
 
-    band = None
-    b = unc.get("band") or unc.get("curve_band")
-    if b:
-        if isinstance(b, dict):
-            band = (
-                np.asarray(b.get("x")),
-                np.asarray(b.get("lo")),
-                np.asarray(b.get("hi")),
-            )
-        elif isinstance(b, (tuple, list)) and len(b) == 3:
-            band = tuple(np.asarray(part) for part in b)
+    band = _normalize_band(unc)
 
     diagnostics = {
         "ess": unc.get("diagnostics", {}).get("ess"),
@@ -268,39 +313,218 @@ def _ensure_result(unc: Union[UncertaintyResult, dict]) -> UncertaintyResult:
         band=band,
     )
 
+def _iter_param_rows(unc_res, peaks, method_label: str):
+    """Yield normalized per-parameter rows for uncertainty exports."""
 
-def write_uncertainty_csv(path: Path, unc: Union[UncertaintyResult, dict]) -> None:
-    """Write uncertainty statistics to ``path``.
+    stats = getattr(unc_res, "stats", None)
+    if stats is None and isinstance(unc_res, dict):
+        stats = unc_res.get("stats")
+        if stats is None:
+            stats = unc_res.get("parameters")
+        if stats is None:
+            stats = unc_res.get("param_stats")
+    if not stats:
+        return
 
-    The CSV schema is a single-row table with per-parameter columns like
-    ``p0_est``, ``p0_sd`` and optional ``p0_p2_5``/``p0_p97_5``.
-    """
+    # support both per-peak and per-parameter layouts
+    if any(isinstance(v, dict) and isinstance(v.get("est"), (list, tuple, np.ndarray)) for v in stats.values()):
+        centers = stats.get("center", {})
+        heights = stats.get("height", {})
+        fwhms = stats.get("fwhm", {})
+        etas = stats.get("eta", {})
 
-    res = _ensure_result(unc)
-    row: Dict[str, float | str] = {"method": res.method_label}
-    for name, stats in res.param_stats.items():
-        row[f"{name}_est"] = stats.get("est")
-        row[f"{name}_sd"] = stats.get("sd")
-        if "p2.5" in stats and "p97.5" in stats:
-            row[f"{name}_p2_5"] = stats.get("p2.5")
-            row[f"{name}_p97_5"] = stats.get("p97.5")
-    df = pd.DataFrame([row])
-    write_dataframe(df, path)
+        est_c = centers.get("est")
+        if est_c is None:
+            est_c = []
+        est_h = heights.get("est")
+        if est_h is None:
+            est_h = []
+        est_w = fwhms.get("est")
+        if est_w is None:
+            est_w = []
+
+        sd_c = centers.get("sd")
+        if sd_c is None:
+            sd_c = []
+        sd_h = heights.get("sd")
+        if sd_h is None:
+            sd_h = []
+        sd_w = fwhms.get("sd")
+        if sd_w is None:
+            sd_w = []
+        est_e = etas.get("est")
+        if est_e is None:
+            est_e = []
+        sd_e = etas.get("sd")
+        if sd_e is None:
+            sd_e = []
+
+        p2_c = centers.get("p2_5")
+        if p2_c is None:
+            p2_c = centers.get("p2.5")
+        if p2_c is None:
+            p2_c = []
+        p2_h = heights.get("p2_5")
+        if p2_h is None:
+            p2_h = heights.get("p2.5")
+        if p2_h is None:
+            p2_h = []
+        p2_w = fwhms.get("p2_5")
+        if p2_w is None:
+            p2_w = fwhms.get("p2.5")
+        if p2_w is None:
+            p2_w = []
+        p2_e = etas.get("p2_5")
+        if p2_e is None:
+            p2_e = etas.get("p2.5")
+        if p2_e is None:
+            p2_e = []
+
+        p97_c = centers.get("p97_5")
+        if p97_c is None:
+            p97_c = centers.get("p97.5")
+        if p97_c is None:
+            p97_c = []
+        p97_h = heights.get("p97_5")
+        if p97_h is None:
+            p97_h = heights.get("p97.5")
+        if p97_h is None:
+            p97_h = []
+        p97_w = fwhms.get("p97_5")
+        if p97_w is None:
+            p97_w = fwhms.get("p97.5")
+        if p97_w is None:
+            p97_w = []
+        p97_e = etas.get("p97_5")
+        if p97_e is None:
+            p97_e = etas.get("p97.5")
+        if p97_e is None:
+            p97_e = []
+        for i, _ in enumerate(peaks, 1):
+            yield {
+                "peak": i,
+                "param": "center",
+                "est": _safe_idx(est_c, i - 1),
+                "sd": _safe_idx(sd_c, i - 1),
+                "p2_5": _safe_idx(p2_c, i - 1),
+                "p97_5": _safe_idx(p97_c, i - 1),
+                "method": method_label,
+            }
+            yield {
+                "peak": i,
+                "param": "height",
+                "est": _safe_idx(est_h, i - 1),
+                "sd": _safe_idx(sd_h, i - 1),
+                "p2_5": _safe_idx(p2_h, i - 1),
+                "p97_5": _safe_idx(p97_h, i - 1),
+                "method": method_label,
+            }
+            yield {
+                "peak": i,
+                "param": "fwhm",
+                "est": _safe_idx(est_w, i - 1),
+                "sd": _safe_idx(sd_w, i - 1),
+                "p2_5": _safe_idx(p2_w, i - 1),
+                "p97_5": _safe_idx(p97_w, i - 1),
+                "method": method_label,
+            }
+            yield {
+                "peak": i,
+                "param": "eta",
+                "est": _safe_idx(est_e, i - 1),
+                "sd": _safe_idx(sd_e, i - 1),
+                "p2_5": _safe_idx(p2_e, i - 1),
+                "p97_5": _safe_idx(p97_e, i - 1),
+                "method": method_label,
+            }
+    else:
+        for i, _ in enumerate(peaks, 1):
+            s = stats.get(i) or stats.get(str(i)) or {}
+            for pname in ("center", "height", "fwhm", "eta"):
+                pdict = s.get(pname) or {}
+                yield {
+                    "peak": i,
+                    "param": pname,
+                    "est": pdict.get("est"),
+                    "sd": pdict.get("sd"),
+                    "p2_5": pdict.get("p2_5") or pdict.get("p2.5"),
+                    "p97_5": pdict.get("p97_5") or pdict.get("p97.5"),
+                    "method": method_label,
+                }
 
 
-def write_uncertainty_txt(path: Path, unc: Union[UncertaintyResult, dict]) -> None:
-    """Write a human readable uncertainty summary to ``path``."""
+def _safe_idx(arr, idx):
+    try:
+        return arr[idx]
+    except Exception:
+        return None
 
-    res = _ensure_result(unc)
-    lines = [f"Method: {res.method_label}"]
-    for name, stats in res.param_stats.items():
-        est = stats.get("est")
-        sd = stats.get("sd")
-        line = f"{name}: {est:.6g} ± {sd:.6g}"
-        if "p2.5" in stats and "p97.5" in stats:
-            line += f"   [2.5%: {stats['p2.5']:.6g}, 97.5%: {stats['p97.5']:.6g}]"
-        lines.append(line)
-    text = "\n".join(lines) + "\n"
-    path.write_text(text, encoding="utf-8")
+
+def write_uncertainty_csv(path: str | Path, unc_res, peaks=None, method_label: str = "") -> None:
+    if peaks is None:
+        res = _ensure_result(unc_res)
+        row: Dict[str, float | str] = {"method": res.method_label}
+        for name, stats in res.param_stats.items():
+            row[f"{name}_est"] = stats.get("est")
+            row[f"{name}_sd"] = stats.get("sd")
+            if "p2.5" in stats and "p97.5" in stats:
+                row[f"{name}_p2_5"] = stats.get("p2.5")
+                row[f"{name}_p97_5"] = stats.get("p97.5")
+        df = pd.DataFrame([row])
+        write_dataframe(df, Path(path))
+        return
+
+    path = Path(path)
+    with path.open("w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(
+            f,
+            fieldnames=["peak", "param", "est", "sd", "p2_5", "p97_5", "method"],
+            lineterminator="\n",
+        )
+        w.writeheader()
+        for row in _iter_param_rows(unc_res, peaks, method_label):
+            w.writerow(row)
+
+
+def write_uncertainty_txt(path: str | Path, unc_res, peaks=None, method_label: str = "") -> None:
+    if peaks is None:
+        res = _ensure_result(unc_res)
+        lines = [f"Method: {res.method_label}"]
+        for name, stats in res.param_stats.items():
+            est = stats.get("est")
+            sd = stats.get("sd")
+            line = f"{name}: {est:.6g} ± {sd:.6g}"
+            if "p2.5" in stats and "p97.5" in stats:
+                line += f"   [2.5%: {stats['p2.5']:.6g}, 97.5%: {stats['p97.5']:.6g}]"
+            lines.append(line)
+        text = "\n".join(lines) + "\n"
+        Path(path).write_text(text, encoding="utf-8")
+        return
+
+    stats = getattr(unc_res, "stats", None)
+    if stats is None and isinstance(unc_res, dict):
+        stats = unc_res.get("stats")
+        if stats is None:
+            stats = unc_res.get("parameters")
+        if stats is None:
+            stats = unc_res.get("param_stats")
+    lines = [f"Uncertainty: {method_label}"]
+    if not stats:
+        lines.append("No parameter statistics available.")
+    else:
+        def fmt(d):
+            est = d.get("est")
+            sd = d.get("sd")
+            if est is None or sd is None:
+                return "n/a"
+            return f"{est:.6g} ± {sd:.3g}"
+
+        for i, _ in enumerate(peaks, 1):
+            s = stats.get(i) or stats.get(str(i)) or {}
+            c = fmt(s.get("center", {}))
+            h = fmt(s.get("height", {}))
+            w = fmt(s.get("fwhm", {}))
+            lines.append(f"Peak {i}: center={c} | height={h} | FWHM={w}")
+    Path(path).write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 

--- a/ui/app.py
+++ b/ui/app.py
@@ -772,6 +772,7 @@ class PeakFitApp:
         self.batch_reheight = tk.BooleanVar(value=bool(self.cfg.get("batch_reheight", False)))
         self.batch_auto_max = tk.IntVar(value=int(self.cfg.get("batch_auto_max", 5)))
         self.batch_save_traces = tk.BooleanVar(value=bool(self.cfg.get("batch_save_traces", False)))
+        self.batch_unc_enabled = tk.BooleanVar(value=bool(self.cfg.get("batch_compute_uncertainty", False)))
 
         self._baseline_cache = {}
 
@@ -811,6 +812,10 @@ class PeakFitApp:
 
         self.show_ci_band = bool(self.cfg.get("ui_show_uncertainty_band", True))
         self.ci_band = None
+        # Uncertainty state
+        self.last_unc_result = None
+        self.last_unc_method = None
+
         self.current_file: Optional[Path] = None
         self.show_ci_band_var = tk.BooleanVar(value=self.show_ci_band)
         self.show_ci_band_var.trace_add("write", self._toggle_ci_band)
@@ -1257,6 +1262,8 @@ class PeakFitApp:
         ttk.Checkbutton(rowb3, text="Save traces", variable=self.batch_save_traces).pack(side=tk.LEFT, padx=4)
         ttk.Label(rowb3, text="Auto max:").pack(side=tk.LEFT, padx=(8,0))
         ttk.Spinbox(rowb3, from_=1, to=20, textvariable=self.batch_auto_max, width=5).pack(side=tk.LEFT)
+        rowb4 = ttk.Frame(batch_box); rowb4.pack(fill=tk.X, pady=2)
+        ttk.Checkbutton(rowb4, text="Compute uncertainty in batch", variable=self.batch_unc_enabled).pack(side=tk.LEFT)
         ttk.Button(batch_box, text="Run Batch…", command=self.run_batch).pack(side=tk.LEFT, pady=4)
 
         # Status bar and log
@@ -1620,7 +1627,7 @@ class PeakFitApp:
         except Exception:
             pass
 
-    def _unc_pretty_label(self, obj) -> str:
+    def _label_from_unc(self, obj) -> str:
         # Accept UncertaintyResult-like, SimpleNamespace, or dict
         try:
             lbl = getattr(obj, "label", None) or getattr(obj, "method_label", None)
@@ -1642,7 +1649,7 @@ class PeakFitApp:
         # Fallback to original label or generic
         return str(lbl) if lbl else "Unknown"
 
-    def _unc_extract_band(self, obj):
+    def _extract_band(self, obj):
         import numpy as np
         # return (x, lo, hi) or None
         # Attribute forms
@@ -2582,11 +2589,10 @@ class PeakFitApp:
                 return
             self.peaks[:] = res.peaks_out
             self.refresh_tree(keep_selection=True)
-            try:
-                self._run_asymptotic_uncertainty()
-            except Exception as e:
-                self.log(f"Uncertainty failed: {e}", level="WARN")
-            self.show_ci_band = bool(self.show_ci_band_var.get())
+            self.last_unc_result = None
+            self.last_unc_method = None
+            self.ci_band = None
+            self.show_ci_band = False
             self.refresh_plot()
             self.set_busy(False, f"Fit done. RMSE {res.rmse:.4g}")
             npts = int(np.count_nonzero(mask))
@@ -2654,7 +2660,6 @@ class PeakFitApp:
             "perf_cache_baseline": bool(self.perf_cache_baseline.get()),
             "perf_seed_all": bool(self.perf_seed_all.get()),
             "perf_max_workers": int(self.perf_max_workers.get()),
-            "unc_method": self.cfg.get("unc_method", "asymptotic"),
             "unc_workers": int(self.cfg.get("unc_workers", 0)),
             "output_dir": str(output_dir),
             "output_base": output_base,
@@ -2669,13 +2674,24 @@ class PeakFitApp:
         self.cfg["batch_reheight"] = bool(self.batch_reheight.get())
         self.cfg["batch_auto_max"] = int(self.batch_auto_max.get())
         self.cfg["batch_save_traces"] = bool(self.batch_save_traces.get())
+        self.cfg["batch_compute_uncertainty"] = bool(self.batch_unc_enabled.get())
         save_config(self.cfg)
+
+        compute_unc = bool(self.batch_unc_enabled.get())
+        unc_method = str(self.unc_method.get()).strip()
 
         def work():
             def prog(i, total, path):
                 self.root.after(0, lambda: self.status_var.set(f"Batch {i}/{total}: {Path(path).name}"))
 
-            return batch_runner.run(patterns, cfg, progress=prog, log=self.log_threadsafe)
+            return batch_runner.run_batch(
+                patterns,
+                cfg,
+                compute_uncertainty=compute_unc,
+                unc_method=unc_method,
+                progress=prog,
+                log=self.log_threadsafe,
+            )
 
         def done(res, err):
             if err or res is None:
@@ -2955,7 +2971,9 @@ class PeakFitApp:
                 self.status_error(f"Uncertainty failed: {error}")
                 return
 
-            label = self._unc_pretty_label(result)
+            label = self._label_from_unc(result)
+            self.last_unc_result = result
+            self.last_unc_method = label
 
             # De-dupe “Computed …” for this job+label
             if getattr(self, "_last_unc_log", None) == (job_id, label):
@@ -2963,10 +2981,14 @@ class PeakFitApp:
             self._last_unc_log = (job_id, label)
 
             # Band
-            band = self._unc_extract_band(result)
+            band = self._extract_band(result)
             self.status_info(f"Computed {label} uncertainty.")
             if band is not None:
-                self.ci_band = band            # store as (x, lo, hi)
+                x, lo, hi = band[:3]
+                try:
+                    self.ci_band = (np.asarray(x), np.asarray(lo), np.asarray(hi))
+                except Exception:
+                    self.ci_band = band
                 self.show_ci_band = True
                 try:
                     self.refresh_plot()
@@ -3251,17 +3273,39 @@ class PeakFitApp:
         with open(paths["trace"], "w", encoding="utf-8", newline="") as fh:
             fh.write(trace_csv)
 
-        try:
-            self._maybe_export_uncertainty(
-                Path(paths["unc_txt"]), Path(paths["unc_csv"]), Path(paths["unc_band"]), rmse
-            )
-        except Exception as e:  # pragma: no cover - defensive
-            self.log(f"Uncertainty export failed: {e}", level="WARN")
+        saved = [paths["fit"], paths["trace"]]
+        if self.last_unc_result is not None:
+            try:
+                data_io.write_uncertainty_txt(
+                    paths["unc_txt"],
+                    self.last_unc_result,
+                    peaks=self.peaks,
+                    method_label=self.last_unc_method or ""
+                )
+                data_io.write_uncertainty_csv(
+                    paths["unc_csv"],
+                    self.last_unc_result,
+                    peaks=self.peaks,
+                    method_label=self.last_unc_method or ""
+                )
+                band = data_io._normalize_band(self.last_unc_result)
+                if band is not None:
+                    xb, lob, hib = band
+                    with open(paths["unc_band"], "w", newline="", encoding="utf-8") as fh:
+                        bw = csv.writer(fh, lineterminator="\n")
+                        bw.writerow(["x", "y_lo95", "y_hi95"])
+                        for xi, lo, hi in zip(xb, lob, hib):
+                            bw.writerow([xi, lo, hi])
+                    saved.append(paths["unc_band"])
+                saved.extend([paths["unc_txt"], paths["unc_csv"]])
+                self.status_info(f"Exported uncertainty ({self.last_unc_method}).")
+            except Exception as e:  # pragma: no cover - defensive
+                self.log(f"Uncertainty export failed: {e}", level="WARN")
+        else:
+            self.status_info("No uncertainty computed — skipping uncertainty export.")
 
-        messagebox.showinfo(
-            "Export",
-            f"Saved:\n{paths['fit']}\n{paths['trace']}\n{paths['unc_txt']}\n{paths['unc_csv']}",
-        )
+        saved_lines = [str(p) for p in saved if p]
+        messagebox.showinfo("Export", "Saved:\n" + "\n".join(saved_lines))
 
     # ----- Plot -----
     def toggle_components(self):


### PR DESCRIPTION
## Summary
- stop automatic uncertainty calculation after each fit and store last uncertainty for manual runs
- export stored uncertainty only when available and add optional batch uncertainty toggle
- update batch runner and I/O helpers to compute and save uncertainty on demand
- normalize band export to avoid numpy truthiness issues and stringify saved paths

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b11e11054c8330b8213ec65d86870b