### PR TITLE
Fix unknown uncertainty labels and ensure stats exports

### DIFF
--- a/core/data_io.py
+++ b/core/data_io.py
@@ -222,12 +222,19 @@ def _canonical_unc_label(label: Optional[str]) -> str:
         or "hessian" in s
         or "linearized" in s
         or "curvature" in s
-        or s == "cov"
+        or "cov" == s
+        or "covariance" in s
+        or "covmatrix" in s
     )
     boot_hits = (
         "boot" in s
-        or "resid" in s
+        or "bootstrap" in s
         or "resample" in s
+        or "resampling" in s
+        or "resid" in s           # residual / residuals
+        or "residual" in s
+        or "percentile" in s
+        or "perc" in s
     )
     bayes_hits = (
         "bayes" in s
@@ -237,6 +244,8 @@ def _canonical_unc_label(label: Optional[str]) -> str:
         or "numpyro" in s
         or "hmc" in s
         or "nuts" in s
+        or "posterior" in s
+        or "chain" in s
     )
 
     if asym_hits:


### PR DESCRIPTION
## Summary
- broaden `_canonical_unc_label` to recognize covariance, residual/resampling, percentile, and Bayesian posterior hints
- normalize arbitrary uncertainty payloads and fill in missing per-peak stats with synthesized CIs
- coerce UI uncertainty results to list-based per-peak stats (including η) and export using the normalized structure
- compute and export uncertainty during batch runs using canonical method labels and shared exporters
- respect batch-uncertainty checkbox and fit window when computing per-file uncertainty

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4c4382fe48330bc09ca344efe153d