### PR TITLE
Compute and export uncertainty during batch fits

### DIFF
--- a/core/data_io.py
+++ b/core/data_io.py
@@ -222,12 +222,19 @@ def _canonical_unc_label(label: Optional[str]) -> str:
         or "hessian" in s
         or "linearized" in s
         or "curvature" in s
-        or s == "cov"
+        or "cov" == s
+        or "covariance" in s
+        or "covmatrix" in s
     )
     boot_hits = (
         "boot" in s
-        or "resid" in s
+        or "bootstrap" in s
         or "resample" in s
+        or "resampling" in s
+        or "resid" in s           # residual / residuals
+        or "residual" in s
+        or "percentile" in s
+        or "perc" in s
     )
     bayes_hits = (
         "bayes" in s
@@ -237,6 +244,8 @@ def _canonical_unc_label(label: Optional[str]) -> str:
         or "numpyro" in s
         or "hmc" in s
         or "nuts" in s
+        or "posterior" in s
+        or "chain" in s
     )
 
     if asym_hits:

--- a/tests/test_unc_label_aliases.py
+++ b/tests/test_unc_label_aliases.py
@@ -1,0 +1,42 @@
+import pytest
+from core.data_io import canonical_unc_label as canon
+
+
+@pytest.mark.parametrize("alias, expected", [
+    ("asym", "Asymptotic (JᵀJ)"),
+    ("jtj", "Asymptotic (JᵀJ)"),
+    ("j^t j", "Asymptotic (JᵀJ)"),
+    ("jᵀ j", "Asymptotic (JᵀJ)"),
+    ("gauss", "Asymptotic (JᵀJ)"),
+    ("hessian", "Asymptotic (JᵀJ)"),
+    ("linearized", "Asymptotic (JᵀJ)"),
+    ("curvature", "Asymptotic (JᵀJ)"),
+    ("cov", "Asymptotic (JᵀJ)"),
+    ("covariance", "Asymptotic (JᵀJ)"),
+    ("covmatrix", "Asymptotic (JᵀJ)"),
+    ("boot", "Bootstrap (residual)"),
+    ("bootstrap", "Bootstrap (residual)"),
+    ("resample", "Bootstrap (residual)"),
+    ("resampling", "Bootstrap (residual)"),
+    ("resid", "Bootstrap (residual)"),
+    ("residual", "Bootstrap (residual)"),
+    ("percentile", "Bootstrap (residual)"),
+    ("perc", "Bootstrap (residual)"),
+    ("bayes", "Bayesian (MCMC)"),
+    ("bayesian", "Bayesian (MCMC)"),
+    ("mcmc", "Bayesian (MCMC)"),
+    ("emcee", "Bayesian (MCMC)"),
+    ("pymc", "Bayesian (MCMC)"),
+    ("numpyro", "Bayesian (MCMC)"),
+    ("hmc", "Bayesian (MCMC)"),
+    ("nuts", "Bayesian (MCMC)"),
+    ("posterior", "Bayesian (MCMC)"),
+    ("chain", "Bayesian (MCMC)"),
+])
+def test_canonical_unc_label_aliases(alias, expected):
+    assert canon(alias) == expected
+
+
+@pytest.mark.parametrize("alias", ["", "foobar", None])
+def test_canonical_unc_label_unknown(alias):
+    assert canon(alias) == "unknown"

--- a/tests/test_unc_normalize_result.py
+++ b/tests/test_unc_normalize_result.py
@@ -1,0 +1,66 @@
+import numpy as np
+import pytest
+from core.data_io import normalize_unc_result
+
+
+def _mk_param_stats_two_peaks():
+    return {
+        "center": {"est": [1.0, 2.0], "sd": [0.01, 0.02]},
+        "height": {"est": [10.0, 20.0], "sd": [0.5, 1.0]},
+        "fwhm": {"est": [0.8, 1.2], "sd": [0.03, 0.04]},
+        "eta": {"est": [0.5, 0.2], "sd": [0.02, 0.01]},
+    }
+
+
+def test_normalize_unc_result_builds_per_peak_rows():
+    inp = {"method": "asymptotic", "param_stats": _mk_param_stats_two_peaks()}
+    out = normalize_unc_result(inp)
+    assert isinstance(out, dict)
+    assert isinstance(out.get("stats"), list)
+    assert len(out["stats"]) == 2
+    p1 = out["stats"][0]
+    assert set(p1.keys()) >= {"center", "height", "fwhm", "eta"}
+    for k in ("center", "height", "fwhm", "eta"):
+        assert "est" in p1[k]
+
+
+def test_normalize_unc_result_handles_numpy_and_missing_label():
+    ps = {
+        "center": {
+            "est": None,
+            "value": None,
+            "mean": None,
+            "median": np.array([1.0, 2.0]),
+            "sd": None,
+            "stderr": None,
+            "sigma": np.array([0.1, 0.2]),
+        },
+        "height": {"est": [5.0, 6.0], "sd": [0.3, 0.4]},
+        "fwhm": {
+            "est": None,
+            "value": None,
+            "mean": None,
+            "median": np.array([0.7, 0.9]),
+            "sd": None,
+            "stderr": None,
+            "sigma": np.array([0.05, 0.06]),
+        },
+        "eta": {"est": [0.2, 0.3], "sd": None, "stderr": None, "sigma": np.array([0.01, 0.02])},
+    }
+    inp = {"method": "bootstrap", "param_stats": ps}
+    out = normalize_unc_result(inp)
+    assert out.get("method") == "bootstrap"
+    assert out.get("label") == "Bootstrap (residual)"
+    assert isinstance(out.get("stats"), list)
+    assert len(out["stats"]) == 2
+    for row in out["stats"]:
+        for k in ("center", "height", "fwhm", "eta"):
+            assert isinstance(row[k]["est"], (int, float))
+            if "sd" in row[k] and row[k]["sd"] is not None:
+                assert isinstance(row[k]["sd"], (int, float))
+
+
+def test_normalize_unc_result_safe_defaults_on_empty():
+    out = normalize_unc_result({})
+    assert out.get("label") == "unknown" or out.get("label") in {None, ""}
+    assert isinstance(out.get("stats"), list)

--- a/ui/app.py
+++ b/ui/app.py
@@ -2948,7 +2948,7 @@ class PeakFitApp:
         write_wide = bool(getattr(self, "cfg", {}).get("export_unc_wide", False))
         long_csv, wide_csv = write_uncertainty_csvs(out_base, file_path, unc_norm, write_wide=write_wide)
 
-        solver_opts = getattr(self, "_solver_options", lambda *_: SimpleNamespace())()
+        solver_opts = getattr(self, "_solver_options", lambda *_: {})()
         if hasattr(solver_opts, "__dict__"):
             solver_opts = solver_opts.__dict__
         solver_meta = {"solver": self.solver_choice.get(), **solver_opts}
@@ -2986,8 +2986,9 @@ class PeakFitApp:
             if band is not None:
                 xb, lob, hib = band
                 band_csv = out_base.with_name(out_base.name + "_uncertainty_band.csv")
+                import csv as _csv
                 with band_csv.open("w", newline="", encoding="utf-8") as fh:
-                    w = csv.writer(fh, lineterminator="\n")
+                    w = _csv.writer(fh, lineterminator="\n")
                     w.writerow(["x", "y_lo95", "y_hi95"])
                     for xi, lo, hi in zip(xb, lob, hib):
                         w.writerow([float(xi), float(lo), float(hi)])

--- a/ui/app.py
+++ b/ui/app.py
@@ -189,10 +189,10 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, List, Tuple, Optional
 from types import SimpleNamespace
 from core.data_io import (
-    _normalize_unc_result,
-    _canonical_unc_label,
     write_uncertainty_csvs,
-    _write_unc_txt,
+    write_uncertainty_txt,
+    normalize_unc_result as _normalize_unc_result,
+    canonical_unc_label as _canonical_unc_label,
 )
 
 import numpy as np
@@ -540,23 +540,6 @@ class ScrollableFrame(ttk.Frame):
 def load_xy_any(path: str):
     """Wrapper around :func:`core.data_io.load_xy` for backwards compatibility."""
     return _dio.load_xy(path)
-
-
-def _unc_method_label(res: Any) -> str:
-    for k in ("method_label", "label", "method", "type"):
-        v = getattr(res, k, None) if not isinstance(res, dict) else res.get(k)
-        if isinstance(v, str) and v.strip():
-            m = v.strip()
-            break
-    else:
-        return "Unknown"
-    m_low = m.lower()
-    return {
-        "asymptotic": "Asymptotic (JᵀJ)",
-        "bootstrap": "Bootstrap (residual)",
-        "bayesian": "Bayesian (MCMC)",
-    }.get(m_low, m)
-
 
 def _coerce_param_stats(res: Any) -> Dict[str, Dict[str, Any]]:
     """Return normalized parameter stats mapping."""
@@ -2857,6 +2840,160 @@ class PeakFitApp:
         )
         return lines, warns
 
+    # --- BEGIN: local helper for canonical method labels ---
+    def _unc_method_label(self, info: dict) -> str:
+        """Return a stable canonical label for an uncertainty method key."""
+        m = str((info or {}).get("method", "")).strip().lower()
+        if m.startswith("asymptotic"):
+            return "Asymptotic (JᵀJ)"
+        if m.startswith("bootstrap"):
+            return "Bootstrap (residual)"
+        if m.startswith("bayes"):
+            return "Bayesian (MCMC)"
+        return "unknown"
+    # --- END: local helper ---
+
+    # --- BEGIN: batch uncertainty helpers ---
+    def _unc_selected_method_key(self) -> str:
+        """Return the canonical uncertainty method key."""
+        label = str(self.unc_method.get()).lower()
+        if label.startswith("asymptotic"):
+            return "asymptotic"
+        if label.startswith("bootstrap"):
+            return "bootstrap"
+        if label.startswith("bayes"):
+            return "bayesian"
+        return label.strip()
+
+    def _compute_uncertainty_sync(self, method: str, x_fit, y_fit, base_fit, add_mode: bool):
+        """Compute uncertainty synchronously for batch processing."""
+        mode = "add" if add_mode else "subtract"
+        theta: list[float] = []
+        for p in self.peaks:
+            theta.extend([p.center, p.height, p.fwhm, p.eta])
+        theta = np.asarray(theta, dtype=float)
+
+        resid_fn = build_residual(x_fit, y_fit, self.peaks, mode, base_fit, "linear", None)
+
+        method_key = method.strip().lower()
+        if method_key.startswith("bootstrap"):
+            method_key = "bootstrap"
+        elif method_key.startswith("asymptotic"):
+            method_key = "asymptotic"
+        elif method_key.startswith("bayes"):
+            method_key = "bayesian"
+
+        if method_key == "asymptotic":
+            res = self._run_asymptotic_uncertainty()
+            if res is None:
+                return {"label": "unknown", "stats": []}
+            cov, _th, _info = res
+            sigma = self._safe_sqrt_vec(np.diag(np.asarray(cov, float)))
+            param_stats = {
+                "center": {"est": [p.center for p in self.peaks], "sd": sigma[0::4].tolist()},
+                "height": {"est": [p.height for p in self.peaks], "sd": sigma[1::4].tolist()},
+                "fwhm": {"est": [p.fwhm for p in self.peaks], "sd": sigma[2::4].tolist()},
+                "eta": {"est": [p.eta for p in self.peaks], "sd": sigma[3::4].tolist()},
+            }
+            out: dict[str, Any] = {
+                "method": "asymptotic",
+                "method_label": "Asymptotic (JᵀJ)",
+                "band": getattr(self, "ci_band", None) or None,
+                "param_stats": param_stats,
+            }
+        elif method_key == "bootstrap":
+            cfg = {
+                "x": x_fit,
+                "y": y_fit,
+                "peaks": self.peaks,
+                "mode": mode,
+                "baseline": base_fit,
+                "theta": theta,
+                "options": self._solver_options(self.bootstrap_solver_choice.get()),
+                "n": 100,
+                "workers": self._resolve_unc_workers(),
+            }
+            res = bootstrap.bootstrap(self.bootstrap_solver_choice.get(), cfg, resid_fn)
+            out = dict(res) if isinstance(res, dict) else {"label": "unknown", "stats": []}
+        elif method_key == "bayesian":
+            init = {
+                "x": x_fit,
+                "y": y_fit,
+                "peaks": self.peaks,
+                "mode": mode,
+                "baseline": base_fit,
+                "theta": theta,
+            }
+            res = bayes.bayesian({}, "gaussian", init, {}, resid_fn)
+            out = dict(res) if isinstance(res, dict) else {"label": "unknown", "stats": []}
+        else:
+            return {"label": "unknown", "stats": []}
+
+        if isinstance(out, dict):
+            out.setdefault("method", method_key)
+            if "label" not in out and "method_label" not in out:
+                out["method_label"] = self._unc_method_label({"method": method_key})
+            ps = out.get("param_stats")
+            if isinstance(ps, dict):
+                for blk in ps.values():
+                    if isinstance(blk, dict):
+                        for k, v in list(blk.items()):
+                            if isinstance(v, np.ndarray):
+                                blk[k] = v.tolist()
+
+        return _normalize_unc_result(out)
+
+    def _export_uncertainty_from_result(self, unc_norm, out_base: Path, file_path: str):
+        """Export uncertainty results to CSV(s) and TXT."""
+        write_wide = bool(getattr(self, "cfg", {}).get("export_unc_wide", False))
+        long_csv, wide_csv = write_uncertainty_csvs(out_base, file_path, unc_norm, write_wide=write_wide)
+
+        solver_opts = getattr(self, "_solver_options", lambda *_: SimpleNamespace())()
+        if hasattr(solver_opts, "__dict__"):
+            solver_opts = solver_opts.__dict__
+        solver_meta = {"solver": self.solver_choice.get(), **solver_opts}
+        baseline_meta = {
+            "uses_fit_range": bool(self.baseline_use_range.get()),
+            "lam": float(self.als_lam.get()),
+            "p": float(self.als_asym.get()),
+            "niter": int(self.als_niter.get()),
+            "thresh": float(self.als_thresh.get()),
+        }
+        perf_meta = {
+            "numba": bool(self.perf_numba.get()),
+            "gpu": bool(self.perf_gpu.get()),
+            "cache_baseline": bool(self.perf_cache_baseline.get()),
+            "seed_all": bool(self.perf_seed_all.get()),
+            "max_workers": int(self.perf_max_workers.get()),
+        }
+        locks = [{"center": bool(getattr(pk, "lock_center", False)),
+                  "fwhm": bool(getattr(pk, "lock_width", False)),
+                  "eta": False} for pk in self.peaks]
+
+        txt_path = out_base.with_name(out_base.name + "_uncertainty.txt")
+        write_uncertainty_txt(
+            txt_path,
+            unc_norm,
+            file_path=file_path,
+            solver_meta=solver_meta,
+            baseline_meta=baseline_meta,
+            perf_meta=perf_meta,
+            locks=locks,
+        )
+
+        if str(unc_norm.get("label", "")).startswith("Asymptotic"):
+            band = unc_norm.get("band")
+            if band is not None:
+                xb, lob, hib = band
+                band_csv = out_base.with_name(out_base.name + "_uncertainty_band.csv")
+                with band_csv.open("w", newline="", encoding="utf-8") as fh:
+                    w = csv.writer(fh, lineterminator="\n")
+                    w.writerow(["x", "y_lo95", "y_hi95"])
+                    for xi, lo, hi in zip(xb, lob, hib):
+                        w.writerow([float(xi), float(lo), float(hi)])
+        return long_csv, wide_csv
+    # --- END: batch uncertainty helpers ---
+
     def run_uncertainty(self):
         if self.x is None or self.y_raw is None or not self.peaks:
             messagebox.showinfo("Uncertainty", "Load data and perform a fit first.")
@@ -2896,9 +3033,22 @@ class PeakFitApp:
                 cov, th, _info = res
                 sigma = self._safe_sqrt_vec(np.diag(np.asarray(cov, float)))
                 param_stats = {
-                    "center": {"est": [p.center for p in self.peaks], "sd": sigma[0::4]},
-                    "fwhm": {"est": [p.fwhm for p in self.peaks], "sd": sigma[2::4]},
-                    "height": {"est": [p.height for p in self.peaks], "sd": sigma[1::4]},
+                    "center": {
+                        "est": [p.center for p in self.peaks],
+                        "sd": sigma[0::4].tolist(),
+                    },
+                    "height": {
+                        "est": [p.height for p in self.peaks],
+                        "sd": sigma[1::4].tolist(),
+                    },
+                    "fwhm": {
+                        "est": [p.fwhm for p in self.peaks],
+                        "sd": sigma[2::4].tolist(),
+                    },
+                    "eta": {
+                        "est": [p.eta for p in self.peaks],
+                        "sd": sigma[3::4].tolist(),
+                    },
                 }
                 return {
                     "method": "asymptotic",
@@ -2943,21 +3093,30 @@ class PeakFitApp:
                                 p_hi = np.quantile(samp, 0.975, axis=0)
 
                             def slice_stats(idx: int) -> Dict[str, Any]:
-                                est = th[idx::4] if th.size else None
-                                sd_i = sd[idx::4] if sd is not None else None
+                                est = th[idx::4].tolist() if th.size else None
+                                sd_i = sd[idx::4].tolist() if sd is not None else None
                                 d: Dict[str, Any] = {"est": est, "sd": sd_i}
                                 if p_lo is not None and p_hi is not None:
-                                    d["p2_5"] = p_lo[idx::4]
-                                    d["p97_5"] = p_hi[idx::4]
+                                    d["p2_5"] = p_lo[idx::4].tolist()
+                                    d["p97_5"] = p_hi[idx::4].tolist()
                                 return d
 
                             res["param_stats"] = {
                                 "center": slice_stats(0),
                                 "height": slice_stats(1),
                                 "fwhm": slice_stats(2),
+                                "eta": slice_stats(3),
                             }
                         except Exception:
                             pass
+                    # Ensure param_stats arrays are lists
+                    ps = res.get("param_stats")
+                    if isinstance(ps, dict):
+                        for blk in ps.values():
+                            if isinstance(blk, dict):
+                                for k, v in blk.items():
+                                    if isinstance(v, np.ndarray):
+                                        blk[k] = v.tolist()
                 return res
             if method == "bayesian":
                 init = {"x": x_fit, "y": y_fit, "peaks": self.peaks, "mode": mode,
@@ -2987,21 +3146,29 @@ class PeakFitApp:
                                 p_hi = np.quantile(samp, 0.975, axis=0)
 
                             def slice_stats(idx: int) -> Dict[str, Any]:
-                                est = th[idx::4] if th.size else None
-                                sd_i = sd[idx::4] if sd is not None else None
+                                est = th[idx::4].tolist() if th.size else None
+                                sd_i = sd[idx::4].tolist() if sd is not None else None
                                 d: Dict[str, Any] = {"est": est, "sd": sd_i}
                                 if p_lo is not None and p_hi is not None:
-                                    d["p2_5"] = p_lo[idx::4]
-                                    d["p97_5"] = p_hi[idx::4]
+                                    d["p2_5"] = p_lo[idx::4].tolist()
+                                    d["p97_5"] = p_hi[idx::4].tolist()
                                 return d
 
                             res["param_stats"] = {
                                 "center": slice_stats(0),
                                 "height": slice_stats(1),
                                 "fwhm": slice_stats(2),
+                                "eta": slice_stats(3),
                             }
                         except Exception:
                             pass
+                    ps = res.get("param_stats")
+                    if isinstance(ps, dict):
+                        for blk in ps.values():
+                            if isinstance(blk, dict):
+                                for k, v in blk.items():
+                                    if isinstance(v, np.ndarray):
+                                        blk[k] = v.tolist()
                 return res
             return {"label": "Aborted", "stats": {}, "diagnostics": {"aborted": True}}
 
@@ -3020,8 +3187,15 @@ class PeakFitApp:
                 self.status_error(f"Uncertainty failed: {error}")
                 return
 
+            res = result
             try:
-                self.last_uncertainty = _normalize_unc_result(result)
+                # Ensure method/label hints are present to avoid 'unknown' in logs/exports
+                if isinstance(res, dict):
+                    # Add robust defaults if the backend didn't set these fields
+                    res.setdefault("method", method)
+                    if "label" not in res and "method_label" not in res:
+                        res["method_label"] = self._unc_method_label({"method": method})
+                self.last_uncertainty = _normalize_unc_result(res)
             except Exception:
                 self.last_uncertainty = {"label": "unknown", "stats": []}
 
@@ -3034,8 +3208,29 @@ class PeakFitApp:
                 })
             self._last_unc_locks = locks
 
-            label = _canonical_unc_label(self.last_uncertainty.get("label"))
+            # Derive a stable, canonical label; fall back to the selected method
+            raw_lbl = (self.last_uncertainty.get("label") or self.last_uncertainty.get("method") or "")
+            label = _canonical_unc_label(raw_lbl)
+            if label == "unknown":
+                # Fallback to UI-selected method if the payload didn't specify a label/method
+                label = self._unc_method_label({"method": method})
+                self.last_uncertainty["method"] = method
             self.last_uncertainty["label"] = label
+
+            # Guarantee per-peak stats even if backend omitted blocks
+            if not (self.last_uncertainty.get("stats") or []):
+                pm = None
+                if isinstance(res, dict):
+                    pm = (
+                        res.get("param_stats")
+                        or res.get("parameters")
+                        or res.get("params")
+                    )
+                if pm is not None:
+                    rebuilt = {"param_stats": pm}
+                    self.last_uncertainty["stats"] = (
+                        _normalize_unc_result(rebuilt).get("stats") or []
+                    )
 
             if label.startswith("Asymptotic"):
                 band = self.last_uncertainty.get("band")
@@ -3080,8 +3275,9 @@ class PeakFitApp:
                     c_est, c_sd = _fmt(row.get("center", {}).get("est"), row.get("center", {}).get("sd"))
                     h_est, h_sd = _fmt(row.get("height", {}).get("est"), row.get("height", {}).get("sd"))
                     w_est, w_sd = _fmt(row.get("fwhm", {}).get("est"), row.get("fwhm", {}).get("sd"))
+                    e_est, e_sd = _fmt(row.get("eta", {}).get("est"), row.get("eta", {}).get("sd"))
                     self.status_info(
-                        f"Peak {i}: center={c_est} ± {c_sd} | height={h_est} ± {h_sd} | FWHM={w_est} ± {w_sd}"
+                        f"Peak {i}: center={c_est} ± {c_sd} | height={h_est} ± {h_sd} | FWHM={w_est} ± {w_sd} | eta={e_est} ± {e_sd}"
                     )
             except Exception as _e:
                 self.status_warn(f"Uncertainty stats formatting skipped ({_e.__class__.__name__}).")
@@ -3117,6 +3313,113 @@ class PeakFitApp:
         save_config(self.cfg)
         self.log(f"Backend: {performance.which_backend()} | workers={performance.get_max_workers()}")
         self.status_var.set("Performance options applied.")
+
+    # --- BEGIN: hook batch runner to compute + export uncertainty ---
+    def _batch_process_file(self, in_path: Path, out_dir: Path):
+        """Process one spectrum: reset band, fit, export fit/trace, then compute and export uncertainty if enabled."""
+        # reset any previous band so batch files don't leak state
+        self.ci_band = None
+        self._open_file(str(in_path))
+        self._do_fit()
+
+        # if no peaks were found/fitted for this file, warn but still write outputs below
+        if not self.peaks:
+            self.status_warn(f"[Batch] No peaks for {in_path.name}; skipping uncertainty.")
+
+        base_csv = out_dir / f"{in_path.stem}_fit.csv"
+        trace_csv = out_dir / f"{in_path.stem}_trace.csv"
+
+        rows = []
+        areas = [pseudo_voigt_area(p.height, p.fwhm, p.eta) for p in self.peaks]
+        total_area = float(np.sum(areas)) if areas else 1.0
+        opts = self._solver_options()
+        center_bounds = (self.fit_xmin, self.fit_xmax) if (opts.get("centers_in_window") or opts.get("bound_centers_to_window")) else (np.nan, np.nan)
+        med_dx = float(np.median(np.diff(np.sort(self.x)))) if (self.x is not None and self.x.size > 1) else 0.0
+        fwhm_lo = opts.get("min_fwhm", max(1e-6, 2.0 * med_dx))
+        for i, (p, a) in enumerate(zip(self.peaks, areas), 1):
+            rows.append(
+                {
+                    "center": p.center,
+                    "height": p.height,
+                    "fwhm": p.fwhm,
+                    "eta": p.eta,
+                    "bounds_center_lo": center_bounds[0],
+                    "bounds_center_hi": center_bounds[1],
+                    "bounds_fwhm_lo": fwhm_lo,
+                    "bounds_height_lo": 0.0,
+                    "bounds_height_hi": np.nan,
+                    "x_scale": opts.get("x_scale", np.nan),
+                }
+            )
+        fit_csv = _dio.build_peak_table(rows)
+        with base_csv.open("w", encoding="utf-8", newline="") as fh:
+            fh.write(fit_csv)
+
+        base_fit = self.baseline if self.use_baseline.get() else None
+        trace_csv_s = _dio.build_trace_table(self.x, self.y_raw, base_fit, self.peaks)
+        with trace_csv.open("w", encoding="utf-8", newline="") as fh:
+            fh.write(trace_csv_s)
+
+        try:
+            # use the real checkbox var; fall back if needed
+            compute_unc_batch = bool(
+                getattr(
+                    self,
+                    "compute_uncertainty_batch",
+                    getattr(self, "batch_unc_enabled", tk.BooleanVar(value=False)),
+                ).get()
+            )
+        except Exception:
+            compute_unc_batch = False
+
+        # don't try uncertainty if there are no peaks
+        if compute_unc_batch and self.peaks:
+            try:
+                method_key = self._unc_selected_method_key()
+                add_mode = bool(self.baseline_mode.get() == "add")
+
+                # --- match single-file uncertainty inputs (fit window + target + add/sub baseline) ---
+                mask = self.current_fit_mask()
+                if mask is None or (isinstance(mask, np.ndarray) and mask.size == 0) or not np.any(mask):
+                    raise RuntimeError("Fit range is empty during batch.")
+                x_fit = self.x[mask]
+                y_fit = self.get_fit_target()[mask]
+                base_for_unc = (
+                    self.baseline[mask]
+                    if (self.use_baseline.get() and add_mode and self.baseline is not None)
+                    else None
+                )
+
+                unc_norm = self._compute_uncertainty_sync(
+                    method_key,
+                    x_fit=x_fit,
+                    y_fit=y_fit,
+                    base_fit=base_for_unc,
+                    add_mode=add_mode,
+                )
+                raw_lbl = unc_norm.get("label") or unc_norm.get("method") or ""
+                label = _canonical_unc_label(raw_lbl)
+                if label == "unknown":
+                    label = self._unc_method_label({"method": method_key})
+                unc_norm["label"] = label
+                out_base = out_dir / in_path.stem
+                self._export_uncertainty_from_result(unc_norm, out_base, str(in_path))
+                self.status_info(f"[Batch] Computed {label} uncertainty for {in_path.name}.")
+            except Exception as e:
+                self.status_warn(f"[Batch] Uncertainty skipped for {in_path.name} ({e.__class__.__name__}).")
+
+    def start_batch(self, in_folder: str, out_folder: str):
+        """Process all spectra in ``in_folder`` writing results to ``out_folder``."""
+        in_dir = Path(in_folder)
+        out_dir = Path(out_folder)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        files = sorted([p for p in in_dir.iterdir() if p.suffix.lower() in {".csv", ".txt", ".dat"}])
+        for p in files:
+            if getattr(self, "_abort_evt", None) and self._abort_evt.is_set():
+                self.status_warn("[Batch] Aborted by user.")
+                break
+            self._batch_process_file(p, out_dir)
+    # --- END: hook batch runner to compute + export uncertainty ---
 
     def on_export(self):
         if self.x is None or self.y_raw is None or not self.peaks:
@@ -3228,9 +3531,6 @@ class PeakFitApp:
                 base = Path(out_csv).with_suffix("")
                 write_wide = bool(getattr(self, "cfg", {}).get("export_unc_wide", False))
 
-                # ensure mapping shape for exporter
-                unc = _normalize_unc_result(unc)
-
                 long_csv, wide_csv = write_uncertainty_csvs(
                     base, self.current_file or "", unc, write_wide=write_wide
                 )
@@ -3258,14 +3558,14 @@ class PeakFitApp:
                 }
                 locks = getattr(self, "_last_unc_locks", [])
                 txt_path = base.with_name(base.name + "_uncertainty.txt")
-                _write_unc_txt(
+                write_uncertainty_txt(
                     txt_path,
-                    self.current_file or "",
                     unc,
-                    solver_meta,
-                    baseline_meta,
-                    perf_meta,
-                    locks,
+                    file_path=self.current_file or "",
+                    solver_meta=solver_meta,
+                    baseline_meta=baseline_meta,
+                    perf_meta=perf_meta,
+                    locks=locks,
                 )
 
                 method_label = unc.get("label", "unknown")


### PR DESCRIPTION
## Summary
- Run the selected uncertainty method for each spectrum in a batch and export long/wide CSV, TXT, and optional band outputs
- Canonicalize uncertainty labels across asymptotic, bootstrap, and Bayesian methods while normalizing per-peak stats
- Add unit tests for canonical label alias mapping and uncertainty result normalization

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4c4382fe48330bc09ca344efe153d