### PR TITLE
Handle uncertainty aliases and bands

### DIFF
--- a/core/data_io.py
+++ b/core/data_io.py
@@ -622,23 +622,34 @@ def _normalize_unc_result(unc: Any) -> Mapping[str, Any]:
 
     # Pull band in a tolerant way
     band = None
-    for key in ("band", "prediction_band", "ci_band"):
+    for key in ("band", "prediction_band", "ci_band", "curve_band"):
         if key in m and m[key] is not None:
             b = m[key]
             if isinstance(b, (list, tuple)) and len(b) >= 3:
                 x, lo, hi = b[0], b[1], b[2]
-                band = (np.asarray(x, float), np.asarray(lo, float), np.asarray(hi, float))
+                # keep JSON-friendly lists while allowing upstream arrays
+                band = (
+                    np.asarray(x, float).tolist(),
+                    np.asarray(lo, float).tolist(),
+                    np.asarray(hi, float).tolist(),
+                )
             break
 
     diag = _as_mapping(m.get("diagnostics"))
 
+    samples_val = m.get("samples", diag.get("n_draws", 0))
+    if isinstance(samples_val, (list, tuple, np.ndarray)):
+        try:
+            samples_val = len(samples_val)
+        except Exception:
+            samples_val = 0
     out = {
         "label": canon,
         "method": method,
         "rmse": _to_float(m.get("rmse")),
         "dof": int(m.get("dof", m.get("d.o.f.", m.get("degrees_of_freedom", 0))) or 0),
         "backend": str(m.get("backend") or diag.get("backend") or m.get("engine") or ""),
-        "n_draws": int(m.get("n_draws", m.get("samples", diag.get("n_draws", 0))) or 0),
+        "n_draws": int(m.get("n_draws", samples_val) or 0),
         "n_boot": int(m.get("n_boot", m.get("bootstraps", diag.get("n_boot", diag.get("bootstraps", 0)))) or 0),
         "ess": _to_float(m.get("ess")),
         "rhat": _to_float(m.get("rhat")),

--- a/tests/test_unc_label_aliases.py
+++ b/tests/test_unc_label_aliases.py
@@ -1,0 +1,26 @@
+import pathlib
+import sys
+
+import pytest
+
+# make package importable
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from core.data_io import canonical_unc_label
+
+
+@pytest.mark.parametrize(
+    "alias, expected",
+    [
+        ("covariance", "Asymptotic (JᵀJ)"),
+        ("J^T J", "Asymptotic (JᵀJ)"),
+        ("residual bootstrap", "Bootstrap (residual)"),
+        ("percentile resampling", "Bootstrap (residual)"),
+        ("emcee sampler", "Bayesian (MCMC)"),
+        ("MCMC chain", "Bayesian (MCMC)"),
+    ],
+)
+def test_unc_label_aliases(alias, expected):
+    """All supported aliases should resolve to canonical labels."""
+    assert canonical_unc_label(alias) == expected
+

--- a/tests/test_unc_normalize_result.py
+++ b/tests/test_unc_normalize_result.py
@@ -1,0 +1,61 @@
+import pathlib
+import sys
+
+import numpy as np
+import pytest
+
+# allow "core" imports
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from core.data_io import normalize_unc_result
+
+
+def test_normalize_result_arrays_and_band():
+    """normalize_unc_result should coerce arrays and map bands."""
+    raw = {
+        "method": "bootstrap",
+        "param_stats": {
+            "center": {"est": np.array([1.0]), "sd": np.array([0.1]), "p97_5": np.array([1.1])},
+            "height": {"est": np.array([2.0]), "sd": np.array([0.2]), "p2_5": np.array([1.8])},
+            "fwhm": {"est": np.array([0.5]), "sd": np.array([0.05])},
+            "eta": {"est": np.array([0.1]), "sd": np.array([0.01])},
+        },
+        "curve_band": [np.array([0.0, 1.0]), np.array([-1.0, -0.5]), np.array([1.0, 1.5])],
+        "n_boot": 10,
+    }
+
+    out = normalize_unc_result(raw)
+    # method resolved to canonical label
+    assert out["label"] == "Bootstrap (residual)"
+    # band becomes lists for json friendliness
+    assert isinstance(out["band"], (list, tuple))
+    xb, lob, hib = out["band"]
+    assert isinstance(xb, list) and xb == [0.0, 1.0]
+    # stats present with floats and percentiles
+    stats0 = out["stats"][0]
+    assert stats0["center"]["sd"] == pytest.approx(0.1)
+    assert stats0["height"]["p2_5"] == pytest.approx(1.8)
+    assert stats0["center"]["p97_5"] == pytest.approx(1.1)
+
+
+def test_normalize_infers_bayesian_from_backend():
+    """Even without an explicit label, backend hints infer the method."""
+    raw = {
+        "backend": "emcee",
+        "samples": np.zeros((5, 2)),
+        "param_stats": {
+            "center": {"est": [1.0], "sd": [0.1], "p2_5": [0.9]},
+            "height": {"est": [2.0], "sd": [0.2], "p97_5": [2.4]},
+            "fwhm": {"est": [0.5], "sd": [0.05]},
+            "eta": {"est": [0.1], "sd": [0.01]},
+        },
+    }
+
+    out = normalize_unc_result(raw)
+    assert out["label"] == "Bayesian (MCMC)"
+    assert out["n_draws"] == 5
+    stats0 = out["stats"][0]
+    # carries percentiles when provided
+    assert stats0["center"]["p2_5"] == pytest.approx(0.9)
+    assert stats0["height"]["p97_5"] == pytest.approx(2.4)
+


### PR DESCRIPTION
## Summary
- Convert heterogenous uncertainty results into canonical forms
- Accept curve_band alias and export JSON-friendly band lists
- Derive draw counts from sample arrays and ensure canonical method labels

## Testing
- `pytest tests/test_unc_label_aliases.py tests/test_unc_normalize_result.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b53b4462548330b00da78ca9ee8e90