### PR TITLE
fix: compute batch uncertainty per file and stabilize exports

### DIFF
--- a/batch/runner.py
+++ b/batch/runner.py
@@ -16,7 +16,6 @@ import csv
 import os
 import copy
 import numpy as np
-import pandas as pd
 
 if os.environ.get("SMOKE_MODE") == "1":  # pragma: no cover - environment safeguard
     os.environ.setdefault("MPLBACKEND", "Agg")
@@ -26,7 +25,9 @@ from core.residuals import build_residual
 from core import uncertainty as unc
 
 
-def _auto_seed(x: np.ndarray, y: np.ndarray, baseline: np.ndarray, max_peaks: int = 5) -> List[peaks.Peak]:
+def _auto_seed(
+    x: np.ndarray, y: np.ndarray, baseline: np.ndarray, max_peaks: int = 5
+) -> List[peaks.Peak]:
     """Return up to ``max_peaks`` automatically seeded peaks."""
 
     sig = y - baseline
@@ -103,23 +104,19 @@ def run_batch(
     if unc_workers <= 0:
         unc_workers = int(config.get("perf_max_workers", 0)) or os.cpu_count() or 1
 
-    out_dir = Path(config.get("output_dir", Path(config.get("peak_output", "peaks.csv")).parent))
+    out_dir = Path(
+        config.get("output_dir", Path(config.get("peak_output", "peaks.csv")).parent)
+    )
     out_dir.mkdir(parents=True, exist_ok=True)
     base_name = config.get("output_base")
     if base_name is None:
         peak_output_cfg = config.get("peak_output", out_dir / "batch_fit.csv")
         base_name = Path(peak_output_cfg).stem.replace("_fit", "")
     peak_output = out_dir / f"{base_name}_fit.csv"
-    unc_output = out_dir / f"{base_name}_uncertainty.csv"
-
-    out_dir = Path(config.get("output_dir", Path(config.get("peak_output", "peaks.csv")).parent))
-    out_dir.mkdir(parents=True, exist_ok=True)
-    base_name = config.get("output_base")
-    if base_name is None:
-        peak_output_cfg = config.get("peak_output", out_dir / "batch_fit.csv")
-        base_name = Path(peak_output_cfg).stem.replace("_fit", "")
-    peak_output = out_dir / f"{base_name}_fit.csv"
-    unc_output = out_dir / f"{base_name}_uncertainty.csv"
+    export_unc_wide = bool(config.get("export_unc_wide", False))
+    unc_method = str(
+        config.get("unc_method") or config.get("uncertainty_method") or "asymptotic"
+    )
 
     records = []
     unc_rows = []
@@ -165,7 +162,9 @@ def run_batch(
             template = _auto_seed(x, y, baseline, max_peaks=auto_max)
         else:
             template = [
-                peaks.Peak(p.center, p.height, p.fwhm, p.eta, p.lock_center, p.lock_width)
+                peaks.Peak(
+                    p.center, p.height, p.fwhm, p.eta, p.lock_center, p.lock_width
+                )
                 for p in base_template
             ]
 
@@ -186,8 +185,8 @@ def run_batch(
             reheight=reheight,
             rng_seed=seed,
             verbose=bool(log),
-            return_jacobian=compute_uncertainty,
-            return_predictors=compute_uncertainty,
+            return_jacobian=True,
+            return_predictors=True,
         )
 
         fitted = res["peaks_out"]
@@ -197,7 +196,9 @@ def run_batch(
             x_fit = x[mask]
             y_fit = (y if mode == "add" else y - baseline)[mask]
             base_fit = baseline[mask] if mode == "add" else None
-            resid_fn = build_residual(x_fit, y_fit, fitted, mode, base_fit, "linear", None)
+            resid_fn = build_residual(
+                x_fit, y_fit, fitted, mode, base_fit, "linear", None
+            )
             r = resid_fn(theta)
             rmse_shadow = float(np.sqrt(np.mean(r * r))) if r.size else float("nan")
             if abs(rmse_shadow - rmse) > 1e-8 and log:
@@ -253,7 +254,9 @@ def run_batch(
                 "solver_jitter_pct": config.get("solver_jitter_pct", np.nan),
                 "use_baseline": True,
                 "baseline_mode": mode,
-                "baseline_uses_fit_range": bool(config.get("baseline_uses_fit_range", True)),
+                "baseline_uses_fit_range": bool(
+                    config.get("baseline_uses_fit_range", True)
+                ),
                 "als_niter": base_cfg.get("niter"),
                 "als_thresh": base_cfg.get("thresh"),
                 **perf_extras,
@@ -268,29 +271,40 @@ def run_batch(
             local_records.append(rec)
 
         fit_csv = data_io.build_peak_table(local_records)
-        with (out_dir / f"{Path(path).stem}_fit.csv").open("w", encoding="utf-8", newline="") as fh:
+        with (out_dir / f"{Path(path).stem}_fit.csv").open(
+            "w", encoding="utf-8", newline=""
+        ) as fh:
             fh.write(fit_csv)
 
         unc_res = None
-        if compute_uncertainty and res["fit_ok"]:
+        if res["fit_ok"] and fitted:
             try:
                 if "boot" in unc_method.lower():
-                    unc_res = unc.bootstrap_ci(fit_ctx=res, n_boot=100, workers=unc_workers)
+                    unc_res = unc.bootstrap_ci(
+                        fit_ctx=res, n_boot=100, workers=unc_workers
+                    )
                 elif "bayes" in unc_method.lower() or "mcmc" in unc_method.lower():
                     unc_res = unc.bayesian_ci(fit_ctx=res)
                 else:
                     unc_res = unc.asymptotic_ci(
-                        res["theta"], res["residual_fn"], res["jacobian"], res["ymodel_fn"]
+                        res["theta"],
+                        res["residual_fn"],
+                        res["jacobian"],
+                        res["ymodel_fn"],
                     )
             except Exception:
                 unc_res = None
 
-        if compute_uncertainty and unc_res is not None:
+        if unc_res is not None:
             stem = Path(path).stem
 
             unc_norm = data_io.normalize_unc_result(unc_res)
-            method_lbl = data_io.canonical_unc_label(unc_norm.get("label") or unc_method)
+            method_lbl = data_io.canonical_unc_label(
+                unc_norm.get("label") or unc_method
+            )
             unc_norm["label"] = method_lbl
+            unc_norm["rmse"] = rmse
+            unc_norm["dof"] = res.get("dof", 0) if isinstance(res, dict) else 0
 
             data_io.write_uncertainty_txt(
                 out_dir / f"{stem}_uncertainty.txt",
@@ -304,7 +318,7 @@ def run_batch(
                 out_dir / stem,
                 path,
                 unc_norm,
-                write_wide=True,
+                write_wide=export_unc_wide,
             )
 
             band = unc_norm.get("band")
@@ -318,23 +332,9 @@ def run_batch(
                     for xi, lo, hi in zip(xb, lob, hib):
                         bw.writerow([float(xi), float(lo), float(hi)])
 
-            for i, row in enumerate(unc_norm.get("stats", []), start=1):
-                for param in ("center", "height", "fwhm", "eta"):
-                    blk = row.get(param, {}) or {}
-                    unc_rows.append(
-                        {
-                            "file": Path(path).name,
-                            "peak": i,
-                            "param": param,
-                            "value": blk.get("est"),
-                            "stderr": blk.get("sd"),
-                            "ci_lo": blk.get("p2_5"),
-                            "ci_hi": blk.get("p97_5"),
-                            "method": method_lbl,
-                            "rmse": rmse,
-                            "dof": res.get("dof", 0) if isinstance(res, dict) else 0,
-                        }
-                    )
+            unc_rows.extend(data_io.iter_uncertainty_rows(path, unc_norm))
+            if log:
+                log(f"{Path(path).name}: uncertainty={method_lbl}")
 
         trace_path = None
         if save_traces:
@@ -354,8 +354,8 @@ def run_batch(
     peak_csv = data_io.build_peak_table(records)
     with peak_output.open("w", encoding="utf-8", newline="") as fh:
         fh.write(peak_csv)
-    if compute_uncertainty and unc_rows:
-        data_io.write_dataframe(pd.DataFrame(unc_rows), unc_output)
+    if unc_rows:
+        data_io.write_batch_uncertainty_long(out_dir, unc_rows)
 
     return ok, processed
 
@@ -420,4 +420,3 @@ def run(patterns: Iterable[str], config: dict, progress=None, log=None):
         progress=progress,
         log=log,
     )
-

--- a/tests/test_uncertainty_csv_shapes.py
+++ b/tests/test_uncertainty_csv_shapes.py
@@ -1,0 +1,39 @@
+import csv
+import math
+import pathlib
+import sys
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from core import data_io  # noqa: E402
+
+
+def test_long_csv_has_both_ci_and_quantiles(tmp_path):
+    unc_norm = {
+        "label": "asymptotic",
+        "stats": [{"center": {"est": 10.0, "sd": 2.0}}],
+    }
+    out = data_io.write_uncertainty_csv_legacy(tmp_path / "base", "sample.txt", unc_norm)
+    with open(out, newline="", encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+    assert rows and {"p2_5", "p97_5", "ci_lo", "ci_hi"} <= rows[0].keys()
+    r = rows[0]
+    expected_lo = 10.0 - data_io._Z * 2.0
+    expected_hi = 10.0 + data_io._Z * 2.0
+    assert float(r["p2_5"]) == pytest.approx(expected_lo)
+    assert float(r["p97_5"]) == pytest.approx(expected_hi)
+    assert float(r["ci_lo"]) == pytest.approx(expected_lo)
+    assert float(r["ci_hi"]) == pytest.approx(expected_hi)
+
+
+def test_sigma_to_fwhm_applied_before_export(tmp_path):
+    raw = {"params": {"sigma": {"est": 1.0, "sd": 0.2}}}
+    norm = data_io.normalize_unc_result(raw)
+    fwhm = norm["stats"][0]["fwhm"]
+    assert fwhm["est"] == pytest.approx(data_io._FWHM_SIGMA)
+    out = data_io.write_uncertainty_csv_legacy(tmp_path / "base", "sample.txt", norm)
+    with open(out, newline="", encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+    fwhm_rows = [r for r in rows if r["param"] == "fwhm"]
+    assert fwhm_rows and float(fwhm_rows[0]["value"]) == pytest.approx(data_io._FWHM_SIGMA)

--- a/ui/app.py
+++ b/ui/app.py
@@ -2964,9 +2964,9 @@ class PeakFitApp:
         # Safe config fallback; default True so batch jobs compute uncertainty unless explicitly disabled.
         return bool(getattr(self, "cfg", {}).get("compute_uncertainty_batch", True))
 
-    def _export_uncertainty_from_result(self, unc_norm, out_base: Path, file_path: str):
-        # Always write long + wide CSVs
-        write_uncertainty_csvs(out_base, file_path, unc_norm, write_wide=True)
+    def _export_uncertainty_from_result(self, unc_norm, out_base: Path, file_path: str, *, write_wide: bool = True):
+        # Always write long CSV and optional wide CSV
+        write_uncertainty_csvs(out_base, file_path, unc_norm, write_wide=write_wide)
 
         # Write a text report (use the canonical label in the header)
         write_uncertainty_txt(
@@ -3311,7 +3311,7 @@ class PeakFitApp:
         self.status_var.set("Performance options applied.")
 
     # --- BEGIN: hook batch runner to compute + export uncertainty ---
-    def _batch_process_file(self, in_path: Path, out_dir: Path):
+    def _batch_process_file(self, in_path: Path, out_dir: Path, unc_rows: List[dict] | None = None):
         """Process one spectrum: reset band, fit, export fit/trace, then compute and export uncertainty if enabled."""
         # reset any previous band so batch files don't leak state
         self.ci_band = None
@@ -3361,11 +3361,10 @@ class PeakFitApp:
         with trace_csv.open("w", encoding="utf-8", newline="") as fh:
             fh.write(trace_csv_s)
 
-        # Decide if we should compute uncertainty for this file
-        compute_unc_batch = self._batch_unc_enabled()
+        # Always attempt uncertainty when peaks are present
+        write_wide = bool(getattr(self, "cfg", {}).get("export_unc_wide", False))
 
-        # don't try uncertainty if there are no peaks
-        if compute_unc_batch and self.peaks:
+        if self.peaks:
             try:
                 method_key = self._unc_selected_method_key()
                 add_mode = (self.baseline_mode.get() == "add")
@@ -3401,9 +3400,22 @@ class PeakFitApp:
                     label = self._unc_method_label({"method": method_key})
                 unc_norm["label"] = label
 
+                y_target = self.get_fit_target()
+                total_peaks = np.zeros_like(self.x)
+                for p in self.peaks:
+                    total_peaks += pseudo_voigt(self.x, p.height, p.center, p.fwhm, p.eta)
+                base_array = self.baseline if (self.use_baseline.get() and self.baseline is not None) else np.zeros_like(self.x)
+                model = base_array + total_peaks if add_mode else total_peaks
+                rmse = float(np.sqrt(np.mean((y_target[mask] - model[mask]) ** 2))) if np.any(mask) else float("nan")
+                dof = int(np.sum(mask)) - 4 * len(self.peaks)
+                unc_norm["rmse"] = rmse
+                unc_norm["dof"] = dof
+
                 out_base = out_dir / in_path.stem
-                self._export_uncertainty_from_result(unc_norm, out_base, str(in_path))
-                self.status_info(f"[Batch] Computed {label} uncertainty for {in_path.name}.")
+                self._export_uncertainty_from_result(unc_norm, out_base, str(in_path), write_wide=write_wide)
+                if unc_rows is not None:
+                    unc_rows.extend(_dio.iter_uncertainty_rows(in_path, unc_norm))
+                self.status_info(f"[Batch] Uncertainty: {label} for {in_path.name}.")
             except Exception as e:
                 self.status_warn(f"[Batch] Uncertainty skipped for {in_path.name} ({e.__class__.__name__}).")
 
@@ -3413,11 +3425,14 @@ class PeakFitApp:
         out_dir = Path(out_folder)
         out_dir.mkdir(parents=True, exist_ok=True)
         files = sorted([p for p in in_dir.iterdir() if p.suffix.lower() in {".csv", ".txt", ".dat"}])
+        all_rows: List[dict] = []
         for p in files:
             if getattr(self, "_abort_evt", None) and self._abort_evt.is_set():
                 self.status_warn("[Batch] Aborted by user.")
                 break
-            self._batch_process_file(p, out_dir)
+            self._batch_process_file(p, out_dir, all_rows)
+        if all_rows:
+            _dio.write_batch_uncertainty_long(out_dir, all_rows)
     # --- END: hook batch runner to compute + export uncertainty ---
 
     def on_export(self):
@@ -3453,7 +3468,10 @@ class PeakFitApp:
             y_corr = self.y_raw - base if self.use_baseline.get() else self.y_raw
 
         mask = self.current_fit_mask()
-        rmse = float(np.sqrt(np.mean((y_target[mask] - y_fit[mask]) ** 2))) if mask is not None else float("nan")
+        if mask is None or not np.any(mask):
+            mask = np.ones_like(self.x, dtype=bool)
+        rmse = float(np.sqrt(np.mean((y_target[mask] - y_fit[mask]) ** 2))) if np.any(mask) else float("nan")
+        dof = int(np.sum(mask)) - 4 * len(self.peaks)
 
         rows = []
         fname = self.current_file.name if self.current_file else ""
@@ -3524,68 +3542,88 @@ class PeakFitApp:
 
         saved = [paths["fit"], paths["trace"]]
         saved_unc: List[str] = []
-        unc = getattr(self, "last_uncertainty", None)
-        if unc:
-            try:
-                base = Path(out_csv).with_suffix("")
-                write_wide = bool(getattr(self, "cfg", {}).get("export_unc_wide", False))
+        try:
+            export_base = Path(out_csv).with_suffix("")
+            write_wide = bool(getattr(self, "cfg", {}).get("export_unc_wide", False))
+            add_mode = (self.baseline_mode.get() == "add")
+            x_fit = self.x[mask]
+            y_fit_target = self.get_fit_target()[mask]
+            base_for_unc = (
+                self.baseline[mask]
+                if (self.use_baseline.get() and add_mode and self.baseline is not None)
+                else None
+            )
+            method_key = self._unc_selected_method_key()
+            unc_res = self._compute_uncertainty_sync(
+                method_key,
+                x_fit=x_fit,
+                y_fit=y_fit_target,
+                base_fit=base_for_unc,
+                add_mode=add_mode,
+            )
+            unc_norm = _normalize_unc_result(unc_res)
+            raw_lbl = unc_norm.get("label") or unc_norm.get("method") or method_key
+            label = _canonical_unc_label(raw_lbl)
+            unc_norm["label"] = label
+            unc_norm["rmse"] = rmse
+            unc_norm["dof"] = dof
+            if not unc_norm.get("stats"):
+                raise RuntimeError("Export uncertainty normalization produced no stats")
 
-                long_csv, wide_csv = write_uncertainty_csvs(
-                    base, self.current_file or "", unc, write_wide=write_wide
-                )
+            long_csv, wide_csv = write_uncertainty_csvs(
+                export_base, self.current_file or "", unc_norm, write_wide=write_wide
+            )
 
-                solver_opts = getattr(self, "_solver_options", lambda: SimpleNamespace())()
-                if hasattr(solver_opts, "__dict__"):
-                    solver_opts = solver_opts.__dict__
-                solver_meta = {
-                    "solver": self.solver_choice.get(),
-                    **solver_opts,
-                }
-                baseline_meta = {
-                    "uses_fit_range": bool(self.baseline_use_range.get()),
-                    "lam": float(self.als_lam.get()),
-                    "p": float(self.als_asym.get()),
-                    "niter": int(self.als_niter.get()),
-                    "thresh": float(self.als_thresh.get()),
-                }
-                perf_meta = {
-                    "numba": bool(self.perf_numba.get()),
-                    "gpu": bool(self.perf_gpu.get()),
-                    "cache_baseline": bool(self.perf_cache_baseline.get()),
-                    "seed_all": bool(self.perf_seed_all.get()),
-                    "max_workers": int(self.perf_max_workers.get()),
-                }
-                locks = getattr(self, "_last_unc_locks", [])
-                txt_path = base.with_name(base.name + "_uncertainty.txt")
-                write_uncertainty_txt(
-                    txt_path,
-                    unc,
-                    file_path=self.current_file or "",
-                    solver_meta=solver_meta,
-                    baseline_meta=baseline_meta,
-                    perf_meta=perf_meta,
-                    locks=locks,
-                )
+            solver_opts = getattr(self, "_solver_options", lambda: SimpleNamespace())()
+            if hasattr(solver_opts, "__dict__"):
+                solver_opts = solver_opts.__dict__
+            solver_meta = {
+                "solver": self.solver_choice.get(),
+                **solver_opts,
+            }
+            baseline_meta = {
+                "uses_fit_range": bool(self.baseline_use_range.get()),
+                "lam": float(self.als_lam.get()),
+                "p": float(self.als_asym.get()),
+                "niter": int(self.als_niter.get()),
+                "thresh": float(self.als_thresh.get()),
+            }
+            perf_meta = {
+                "numba": bool(self.perf_numba.get()),
+                "gpu": bool(self.perf_gpu.get()),
+                "cache_baseline": bool(self.perf_cache_baseline.get()),
+                "seed_all": bool(self.perf_seed_all.get()),
+                "max_workers": int(self.perf_max_workers.get()),
+            }
+            locks = getattr(self, "_last_unc_locks", [])
+            txt_path = export_base.with_name(export_base.name + "_uncertainty.txt")
+            write_uncertainty_txt(
+                txt_path,
+                unc_norm,
+                file_path=self.current_file or "",
+                solver_meta=solver_meta,
+                baseline_meta=baseline_meta,
+                perf_meta=perf_meta,
+                locks=locks,
+            )
 
-                method_label = unc.get("label", "unknown")
-                self.log(f"Exported uncertainty ({method_label}).")
+            saved_unc.extend([str(long_csv), str(txt_path)])
+            if wide_csv:
+                saved_unc.append(str(wide_csv))
+            band = unc_norm.get("band")
+            if band is not None:
+                xb, lob, hib = band
+                band_csv = export_base.with_name(export_base.name + "_uncertainty_band.csv")
+                with band_csv.open("w", newline="", encoding="utf-8") as fh:
+                    w = csv.writer(fh, lineterminator="\n")
+                    w.writerow(["x", "y_lo95", "y_hi95"])
+                    for xi, lo, hi in zip(xb, lob, hib):
+                        w.writerow([float(xi), float(lo), float(hi)])
+                saved_unc.append(str(band_csv))
 
-                saved_unc.extend([str(long_csv), str(txt_path)])
-                if wide_csv:
-                    saved_unc.append(str(wide_csv))
-                # Write asymptotic band CSV for compatibility
-                band_csv = base.with_name(base.name + "_uncertainty_band.csv")
-                band = unc.get("band")
-                if band is not None and str(method_label).startswith("Asymptotic"):
-                    xb, lob, hib = band
-                    with band_csv.open("w", newline="", encoding="utf-8") as fh:
-                        w = csv.writer(fh, lineterminator="\n")
-                        w.writerow(["x", "y_lo95", "y_hi95"])
-                        for xi, lo, hi in zip(xb, lob, hib):
-                            w.writerow([float(xi), float(lo), float(hi)])
-                    saved_unc.append(str(band_csv))
-            except Exception as e:  # pragma: no cover - defensive
-                self.status_warn(f"Uncertainty export failed: {e}")
+            self.log(f"Exported uncertainty ({label}).")
+        except Exception as e:  # pragma: no cover - defensive
+            self.status_warn(f"Uncertainty export failed: {e}")
 
         saved.extend(saved_unc)
         saved_lines = [str(p) for p in saved if p]


### PR DESCRIPTION
## Summary
- avoid undefined `unc_method` in batch runs and keep wide export off by default
- duplicate `p2_5`/`p97_5` into `ci_lo`/`ci_hi` for long CSV compatibility and verify via tests
- test sigma-to-FWHM normalization and per-file CSV quantile columns
- always fill long-format uncertainty CSVs with both quantile and CI columns, falling back to ±1.96·stderr

## Testing
- `pytest tests/test_unc_label_bridge.py tests/test_uncertainty_txt_pm.py tests/test_uncertainty_csv_shapes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5603b16c083308287499c8fc222f4