### PR TITLE
Seed peaks and uncertainty method in batch runner

### DIFF
--- a/batch/runner.py
+++ b/batch/runner.py
@@ -98,6 +98,11 @@ def run_batch(
     base_cfg = config.get("baseline", {})
     save_traces = bool(config.get("save_traces", False))
     source = config.get("source", "template")
+    # Fallback: if no seed peaks provided and not explicitly auto, switch to auto seeding
+    if source != "auto" and not base_template:
+        if log:
+            log("no seed peaks provided; switching source=auto")
+        source = "auto"
     reheight = bool(config.get("reheight", False))
     auto_max = int(config.get("auto_max", 5))
     unc_workers = int(config.get("unc_workers", 0))

--- a/core/data_io.py
+++ b/core/data_io.py
@@ -1171,14 +1171,31 @@ def write_batch_uncertainty_long(
       - batch_uncertainty.csv      (legacy-compatible mirror)
     """
     out_dir = Path(out_dir)
-    header = ["file","peak","param","value","stderr","p2_5","p97_5","method","rmse","dof"]
+    header = ["file","peak","param","value","stderr","ci_lo","ci_hi","method","rmse","dof"]
 
     def _write(path: Path):
         with path.open("w", newline="", encoding="utf-8") as fh:
             w = csv.DictWriter(fh, fieldnames=header, lineterminator="\n")
             w.writeheader()
             for r in rows:
-                w.writerow(r)
+                val = _to_float(r.get("value"))
+                sd = _to_float(r.get("stderr"))
+                qlo = _to_float(r.get("p2_5"))
+                qhi = _to_float(r.get("p97_5"))
+                if (math.isnan(qlo) or math.isnan(qhi)) and math.isfinite(val) and math.isfinite(sd):
+                    qlo, qhi = val - _Z * sd, val + _Z * sd
+                w.writerow({
+                    "file": r.get("file", ""),
+                    "peak": r.get("peak", ""),
+                    "param": r.get("param", ""),
+                    "value": val,
+                    "stderr": sd,
+                    "ci_lo": qlo,
+                    "ci_hi": qhi,
+                    "method": r.get("method", ""),
+                    "rmse": r.get("rmse", ""),
+                    "dof": r.get("dof", ""),
+                })
 
     long_path = out_dir / "batch_uncertainty_long.csv"
     legacy_path = out_dir / "batch_uncertainty.csv"

--- a/ui/app.py
+++ b/ui/app.py
@@ -3416,28 +3416,45 @@ class PeakFitApp:
 
     def start_batch(self, in_folder: str, out_folder: str):
         """Process all spectra in ``in_folder`` writing results to ``out_folder``."""
-        # Ensure batch sees the selected uncertainty method and defaults to computing uncertainty
+        # Persist the selected uncertainty method for future sessions
         try:
             method_key = self._unc_selected_method_key()
             self.cfg["unc_method"] = method_key
-            if "compute_uncertainty_batch" not in self.cfg:
-                self.cfg["compute_uncertainty_batch"] = True
             save_config(self.cfg)
         except Exception:
             pass
-        in_dir = Path(in_folder)
-        out_dir = Path(out_folder)
-        out_dir.mkdir(parents=True, exist_ok=True)
-        files = sorted([p for p in in_dir.iterdir() if p.suffix.lower() in {".csv", ".txt", ".dat"}])
-        all_rows: List[dict] = []
-        for p in files:
-            if getattr(self, "_abort_evt", None) and self._abort_evt.is_set():
-                self.status_warn("[Batch] Aborted by user.")
-                break
-            self._batch_process_file(p, out_dir, all_rows)
-        if all_rows:
-            _dio.write_batch_uncertainty_long(out_dir, all_rows)
-    # --- END: hook batch runner to compute + export uncertainty ---
+        # Seed the batch runner with the current peaks and selected uncertainty method.
+        # Use the template seeds for all files; let batch reheight per spectrum.
+        from batch import runner as batch_runner
+        seed_peaks = [
+            {
+                "center": p.center,
+                "height": p.height,
+                "fwhm": p.fwhm,
+                "eta": p.eta,
+                "lock_center": getattr(p, "lock_center", False),
+                "lock_width": getattr(p, "lock_width", False),
+            }
+            for p in (self.peaks or [])
+        ]
+        batch_runner.run_from_dir(
+            input_dir=in_folder,
+            output_dir=out_folder,
+            # IMPORTANT: use template seeds we just passed
+            source_mode="template",
+            workers=int(self.perf_max_workers.get()),
+            perf_overrides={
+                "peaks": seed_peaks,
+                "reheight": True,
+                # forward uncertainty selection + exporting preference
+                "unc_method": self._unc_selected_method_key(),
+                "export_unc_wide": bool(getattr(self, "cfg", {}).get("export_unc_wide", False)),
+                # fit window + baseline behavior, so per-file uncertainty matches single-file UI
+                "fit_xmin": getattr(self, "fit_xmin", None),
+                "fit_xmax": getattr(self, "fit_xmax", None),
+                "baseline_uses_fit_range": bool(getattr(self, "baseline_use_range", tk.BooleanVar(value=True)).get()),
+            },
+        )
 
     def on_export(self):
         if self.x is None or self.y_raw is None or not self.peaks:


### PR DESCRIPTION
## Summary
- Seed batch runs with current peaks and forward the selected uncertainty method
- Fallback to auto seeding when no template peaks are provided
- Export batch uncertainty summaries with `ci_lo`/`ci_hi` columns

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5cef780648330a9ae30bb61310828