### PR TITLE
Ensure fresh uncertainty calculation for single and batch exports

### DIFF
--- a/batch/runner.py
+++ b/batch/runner.py
@@ -125,6 +125,7 @@ def run_batch(
     unc_method_canon = data_io.canonical_unc_label(unc_choice)
     if log:
         log(f"batch uncertainty method={unc_method_canon}")
+        log(f"batch compute_uncertainty={bool(compute_uncertainty)}")
 
     records = []
     unc_rows = []
@@ -295,11 +296,12 @@ def run_batch(
                 elif "bayes" in mode_lower or "mcmc" in mode_lower:
                     unc_res = unc.bayesian_ci(fit_ctx=res)
                 else:
+                    # NOTE: fit_api returns `predict_full` for the model evaluator
                     unc_res = unc.asymptotic_ci(
                         res["theta"],
                         res["residual_fn"],
                         res["jacobian"],
-                        res["ymodel_fn"],
+                        res["predict_full"],
                     )
             except Exception:
                 unc_res = None

--- a/ui/app.py
+++ b/ui/app.py
@@ -2693,11 +2693,29 @@ class PeakFitApp:
         self.cfg["batch_reheight"] = bool(self.batch_reheight.get())
         self.cfg["batch_auto_max"] = int(self.batch_auto_max.get())
         self.cfg["batch_save_traces"] = bool(self.batch_save_traces.get())
-        self.cfg["batch_compute_uncertainty"] = bool(self.batch_unc_enabled.get())
+        try:
+            self.cfg["batch_compute_uncertainty"] = bool(self.batch_unc_enabled.get())
+        except Exception:
+            try:
+                self.cfg["batch_compute_uncertainty"] = bool(self.compute_uncertainty_batch.get())
+            except Exception:
+                self.cfg["batch_compute_uncertainty"] = True
         save_config(self.cfg)
 
-        compute_unc = bool(self.batch_unc_enabled.get())
+        # Respect the UI toggle if present; otherwise default ON to avoid silent skips.
+        compute_unc = True
+        try:
+            compute_unc = bool(self.batch_unc_enabled.get())
+        except Exception:
+            try:
+                compute_unc = bool(self.compute_uncertainty_batch.get())
+            except Exception:
+                compute_unc = True
         unc_method = str(self.unc_method.get()).strip()
+
+        self.log("Starting batch…")
+        # Helpful visibility when debugging batch behavior:
+        self.log(f"Batch: compute_uncertainty={compute_unc} | method={unc_method}")
 
         def work():
             def prog(i, total, path):
@@ -3355,6 +3373,7 @@ class PeakFitApp:
         with trace_csv.open("w", encoding="utf-8", newline="") as fh:
             fh.write(trace_csv_s)
 
+        # Always decide via the batch toggle (not GUI history). If disabled or no peaks, skip with a log line.
         write_wide = bool(getattr(self, "cfg", {}).get("export_unc_wide", False))
 
         if self.peaks and self._batch_unc_enabled():
@@ -3362,12 +3381,9 @@ class PeakFitApp:
                 method_key = self._unc_selected_method_key()
                 add_mode = (self.baseline_mode.get() == "add")
 
-                # --- match single-file uncertainty inputs (fit window + target + add/sub baseline) ---
+                # Fit window mask: fall back to full range if empty
                 mask = self.current_fit_mask()
-
-                # If the prior file’s window doesn’t overlap this file’s x-domain, mask can be empty.
-                # In batch, fall back to full range so we still compute uncertainty instead of silently skipping.
-                if mask is None or (isinstance(mask, np.ndarray) and mask.size == 0) or not np.any(mask):
+                if mask is None or (isinstance(mask, np.ndarray) and (mask.size == 0 or not np.any(mask))):
                     mask = np.ones_like(self.x, dtype=bool)
 
                 x_fit = self.x[mask]
@@ -3385,12 +3401,11 @@ class PeakFitApp:
                     base_fit=base_for_unc,
                     add_mode=add_mode,
                 )
-                # Normalize + canonicalize the label so exports/logs are consistent
+
+                # Normalize, label, attach RMSE/DOF (using current file context)
                 unc_norm = _normalize_unc_result(unc_res)
                 raw_lbl = (unc_norm.get("label") or unc_norm.get("method") or "")
-                label = _canonical_unc_label(raw_lbl)
-                if label == "unknown":
-                    label = self._unc_method_label({"method": method_key})
+                label = _canonical_unc_label(raw_lbl) or self._unc_method_label({"method": method_key})
                 unc_norm["label"] = label
 
                 y_target = self.get_fit_target()
@@ -3406,8 +3421,11 @@ class PeakFitApp:
 
                 out_base = out_dir / in_path.stem
                 self._export_uncertainty_from_result(unc_norm, out_base, str(in_path), write_wide=write_wide)
+
+                # Append to batch-unc summary rows
                 if unc_rows is not None:
                     unc_rows.extend(_dio.iter_uncertainty_rows(in_path, unc_norm))
+
                 self.status_info(f"[Batch] Uncertainty: {label} for {in_path.name}.")
             except Exception as e:
                 self.status_warn(f"[Batch] Uncertainty skipped for {in_path.name} ({e.__class__.__name__}).")
@@ -3416,28 +3434,30 @@ class PeakFitApp:
 
     def start_batch(self, in_folder: str, out_folder: str):
         """Process all spectra in ``in_folder`` writing results to ``out_folder``."""
-        # Ensure batch sees the selected uncertainty method and defaults to computing uncertainty
+        # Persist the selected uncertainty method for future sessions
         try:
             method_key = self._unc_selected_method_key()
             self.cfg["unc_method"] = method_key
-            if "compute_uncertainty_batch" not in self.cfg:
-                self.cfg["compute_uncertainty_batch"] = True
             save_config(self.cfg)
         except Exception:
             pass
+
         in_dir = Path(in_folder)
         out_dir = Path(out_folder)
         out_dir.mkdir(parents=True, exist_ok=True)
         files = sorted([p for p in in_dir.iterdir() if p.suffix.lower() in {".csv", ".txt", ".dat"}])
+
         all_rows: List[dict] = []
         for p in files:
             if getattr(self, "_abort_evt", None) and self._abort_evt.is_set():
                 self.status_warn("[Batch] Aborted by user.")
                 break
             self._batch_process_file(p, out_dir, all_rows)
+
+        # Batch summaries (fit already written per-file; now write uncertainty summaries if any rows)
         if all_rows:
             _dio.write_batch_uncertainty_long(out_dir, all_rows)
-    # --- END: hook batch runner to compute + export uncertainty ---
+        self.status_info(f"Batch done: processed {len(files)} files.")
 
     def on_export(self):
         if self.x is None or self.y_raw is None or not self.peaks:
@@ -3548,34 +3568,34 @@ class PeakFitApp:
             export_base = Path(out_csv).with_suffix("")
             write_wide = bool(getattr(self, "cfg", {}).get("export_unc_wide", False))
 
-            # 1) Reuse last run’s uncertainty if we have it
-            unc = getattr(self, "last_uncertainty", None)
-            if unc is None:
-                # fallback: compute now using the selected method
-                method_key = self._unc_selected_method_key()
-                add_mode = (self.baseline_mode.get() == "add")
-                x_fit = self.x[mask]
-                y_fit_target = self.get_fit_target()[mask]
-                base_for_unc = (
-                    self.baseline[mask]
-                    if (self.use_baseline.get() and add_mode and self.baseline is not None)
-                    else None
-                )
-                unc = self._compute_uncertainty_sync(
-                    method_key,
-                    x_fit=x_fit,
-                    y_fit=y_fit_target,
-                    base_fit=base_for_unc,
-                    add_mode=add_mode,
-                )
+            # --- Always compute uncertainty fresh at export time ---
+            method_key = self._unc_selected_method_key()
+            add_mode = (self.baseline_mode.get() == "add")
 
-            # 2) Normalize, label, and set rmse/dof
-            unc_norm = _normalize_unc_result(unc)
-            raw_lbl = (
-                unc_norm.get("label")
-                or unc_norm.get("method")
-                or self._unc_selected_method_key()
+            # Fit window mask: if empty or None, fall back to full range so we never skip
+            mask = self.current_fit_mask()
+            if mask is None or (isinstance(mask, np.ndarray) and (mask.size == 0 or not np.any(mask))):
+                mask = np.ones_like(self.x, dtype=bool)
+
+            x_fit = self.x[mask]
+            y_fit_target = self.get_fit_target()[mask]
+            base_for_unc = (
+                self.baseline[mask]
+                if (self.use_baseline.get() and add_mode and self.baseline is not None)
+                else None
             )
+
+            unc = self._compute_uncertainty_sync(
+                method_key,
+                x_fit=x_fit,
+                y_fit=y_fit_target,
+                base_fit=base_for_unc,
+                add_mode=add_mode,
+            )
+
+            # Normalize + canonicalize label, then attach RMSE/DOF from current export context
+            unc_norm = _normalize_unc_result(unc)
+            raw_lbl = (unc_norm.get("label") or unc_norm.get("method") or method_key)
             label = _canonical_unc_label(raw_lbl)
             unc_norm["label"] = label
             unc_norm["rmse"] = rmse
@@ -3583,12 +3603,12 @@ class PeakFitApp:
             if not unc_norm.get("stats"):
                 raise RuntimeError("Export uncertainty normalization produced no stats")
 
-            # 3) CSVs
+            # CSVs (long + optional wide)
             long_csv, wide_csv = write_uncertainty_csvs(
                 export_base, self.current_file or "", unc_norm, write_wide=write_wide
             )
 
-            # 4) TXT — IMPORTANT: pass peaks + method_label
+            # TXT — pass peaks + method_label and metadata as before
             solver_opts = getattr(self, "_solver_options", lambda: SimpleNamespace())()
             if hasattr(solver_opts, "__dict__"):
                 solver_opts = solver_opts.__dict__
@@ -3625,7 +3645,7 @@ class PeakFitApp:
             if wide_csv:
                 saved_unc.append(str(wide_csv))
 
-            # band, if present
+            # Band, if present (asymptotic and any method that provides it)
             band = unc_norm.get("band")
             if band is not None:
                 xb, lob, hib = band


### PR DESCRIPTION
## Summary
- Always recompute uncertainty on export using the current method and fit mask
- Batch processing recomputes uncertainty per file respecting UI toggle and fit window
- Batch runner logs compute_uncertainty and uses `predict_full` for asymptotic CI
- Batch GUI defaults to computing uncertainty when the toggle is missing and logs the chosen settings

## Testing
- `pytest tests/test_batch_uncertainty_summary.py::test_batch_uncertainty_summary -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5d6e8a36c8330b753294110386a22