### PR TITLE
Improve uncertainty normalization and batch asymptotic handling

### DIFF
--- a/tests/test_unc_bootstrap_outputs.py
+++ b/tests/test_unc_bootstrap_outputs.py
@@ -1,4 +1,5 @@
 import numpy as np
+import math
 from pathlib import Path
 from core import fit_api, uncertainty, data_io
 from tests.conftest import _maybe_read_unc_files, _pivot_long_to_wide
@@ -13,6 +14,11 @@ def test_unc_bootstrap_outputs(two_peak_data, tmp_path):
 
     base = Path(tmp_path / "out.csv")
     unc_norm = data_io.normalize_unc_result(res1)
+    for row in unc_norm["stats"]:
+        for pname in ("center", "height", "fwhm", "eta"):
+            p = row[pname]
+            assert math.isfinite(p.get("est", float("nan")))
+            assert math.isfinite(p.get("sd", float("nan")))
     data_io.write_uncertainty_csvs(base, "", unc_norm, write_wide=True)
     basedir = Path(tmp_path)
     stem = "out"

--- a/tests/test_unc_param_mean_std.py
+++ b/tests/test_unc_param_mean_std.py
@@ -1,0 +1,18 @@
+import math
+import numpy as np
+from core import data_io
+
+
+def test_normalize_param_mean_std():
+    mean = np.arange(8, dtype=float)
+    std = np.full(8, 0.1)
+    unc = {"param_mean": mean, "param_std": std}
+    norm = data_io.normalize_unc_result(unc)
+    assert len(norm["stats"]) == 2
+    for row in norm["stats"]:
+        for pname in ("center", "height", "fwhm", "eta"):
+            blk = row[pname]
+            assert math.isfinite(blk.get("est", float("nan")))
+            assert math.isfinite(blk.get("sd", float("nan")))
+            assert math.isfinite(blk.get("p2_5", float("nan")))
+            assert math.isfinite(blk.get("p97_5", float("nan")))

--- a/tests/test_unc_samples_only.py
+++ b/tests/test_unc_samples_only.py
@@ -1,0 +1,14 @@
+import math
+import numpy as np
+from core import data_io
+
+
+def test_normalize_samples_only():
+    unc = {"label": "Bootstrap (residual)", "params": {"samples": np.random.randn(50, 8)}}
+    norm = data_io.normalize_unc_result(unc)
+    assert len(norm["stats"]) == 2
+    for row in norm["stats"]:
+        for pname in ("center", "height", "fwhm", "eta"):
+            blk = row[pname]
+            assert math.isfinite(blk.get("est", float("nan")))
+            assert math.isfinite(blk.get("sd", float("nan")))


### PR DESCRIPTION
## Summary
- Make uncertainty stat extraction handle diverse aliases and synthesize quantiles
- Normalize uncertainty results consistently and share stats/param_stats
- Fix batch asymptotic CI path to use residual_jac and ensure finite rmse/dof
- Route GUI bootstrap path through core bootstrap_ci and log exported file paths
- Add regression tests for bootstrap stats and raw-sample normalization
- Handle param_mean/param_std inputs when no stats are provided and log batch uncertainty errors

## Testing
- `pytest tests/test_unc_bootstrap_outputs.py::test_unc_bootstrap_outputs tests/test_unc_samples_only.py::test_normalize_samples_only tests/test_unc_param_mean_std.py::test_normalize_param_mean_std -q`
- `pytest tests/test_batch_band_written.py::test_batch_band_written tests/test_batch_output_dir.py::test_batch_output_dir tests/test_batch_outputs_in_selected_dir.py::test_batch_outputs_in_selected_dir tests/test_batch_summary_no_nan.py::test_batch_summary_no_nan tests/test_batch_toggle_respected.py::test_batch_toggle_respected tests/test_batch_unc_method_selection.py::test_batch_uses_bayesian_when_configured tests/test_batch_wide_toggle.py::test_batch_wide_toggle -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6d77129d88330a52a54e1b619a3bc