### PR TITLE
Add strict uncertainty routing and enforce unknown method errors

### DIFF
--- a/core/uncertainty_router.py
+++ b/core/uncertainty_router.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+from typing import Any, Callable, Dict, Optional
+import numpy as np
+
+from .data_io import canonical_unc_label
+from . import uncertainty as unc
+
+
+def route_uncertainty(
+    method: str,
+    *,
+    theta_hat: np.ndarray,
+    residual_fn: Callable[[np.ndarray], np.ndarray],
+    jacobian: Any,
+    model_eval: Optional[Callable[[np.ndarray, np.ndarray], np.ndarray]] = None,
+    fit_ctx: Optional[Dict[str, Any]] = None,
+    workers: int = 0,
+    seed: Optional[int] = None,
+    n_boot: int = 100,
+    bayes_steps: int = 8000,
+    bayes_burn: int = 2000,
+) -> Any:
+    """Dispatch to asymptotic, bootstrap, or bayesian. No fallback."""
+    canon = canonical_unc_label(method)
+    s = canon.lower()
+
+    # Materialize J or wrap callable for asymptotic
+    if callable(jacobian):
+        J_fn = jacobian
+        J_mat = None
+    else:
+        J_mat = np.asarray(jacobian, float)
+        J_fn = lambda _th: J_mat  # type: ignore
+
+    if s.startswith("asymptotic"):
+        return unc.asymptotic_ci(theta_hat, residual_fn, J_fn, model_eval)
+
+    if s.startswith("bootstrap"):
+        if J_mat is None:
+            J_mat = np.asarray(J_fn(theta_hat), float)
+        r0 = residual_fn(theta_hat)
+        return unc.bootstrap_ci(
+            theta=theta_hat,
+            residual=r0,
+            jacobian=J_mat,
+            predict_full=model_eval,
+            fit_ctx=fit_ctx or {},
+            n_boot=int(n_boot),
+            workers=int(workers),
+            seed=seed,
+        )
+
+    if s.startswith("bayesian"):
+        return unc.bayesian_ci(
+            theta_hat=theta_hat,
+            model=model_eval,
+            residual_fn=residual_fn,
+            fit_ctx=fit_ctx or {},
+            n_steps=int(bayes_steps),
+            n_burn=int(bayes_burn),
+            seed=seed,
+            return_band=True,
+        )
+
+    raise ValueError(f"Unknown uncertainty method: '{method}' -> '{canon}'")

--- a/tests/test_batch_fd_jacobian_path.py
+++ b/tests/test_batch_fd_jacobian_path.py
@@ -1,0 +1,78 @@
+import numpy as np
+import pytest
+import types
+from pathlib import Path
+
+
+def _fake_fit_ctx(x, y):
+    # One-peak theta = [c, h, fwhm, eta]
+    th = np.array([1.0, 1.0, 1.0, 0.5], float)
+    peak = types.SimpleNamespace(
+        center=1.0, height=1.0, fwhm=1.0, eta=0.5, lock_center=False, lock_width=False
+    )
+    return {
+        "fit_ok": True,
+        "theta": th,
+        "x": x,
+        "y": y,
+        "x_fit": list(x),
+        "y_fit": list(y),
+        "peaks": [peak],
+        "peaks_out": [peak],
+        "baseline": np.zeros_like(x),
+        "mode": "add",
+        # Crucially omit both 'residual_jac' and 'jacobian' to hit FD path.
+        # Also omit 'residual_fn' so runner builds it via build_residual.
+        "dof": max(1, x.size - 4),
+        "fit_ok_msg": "ok",
+        "rmse": 1.0,
+    }
+
+
+def test_asymptotic_uses_fd_when_no_jacobian(tmp_path, monkeypatch):
+    f = tmp_path / "toy.txt"
+    f.write_text("0 0\n1 1\n2 0\n")
+
+    # Stub I/O and baseline
+    from core import data_io as dio
+
+    monkeypatch.setattr(
+        dio, "load_xy", lambda p: (np.array([0.0, 1.0, 2.0]), np.array([0.0, 1.0, 0.0])))
+
+    from core import signals
+
+    monkeypatch.setattr(signals, "als_baseline", lambda y, **k: np.zeros_like(y))
+
+    # Make run_fit produce a context lacking jacobian/residual_fn
+    from core import fit_api
+
+    monkeypatch.setattr(
+        fit_api, "run_fit_consistent", lambda *a, **k: _fake_fit_ctx(*a[:2])
+    )
+
+    # Execute batch with asymptotic to exercise FD path
+    from batch.runner import run_batch
+    from core import models
+
+    monkeypatch.setattr(
+        models, "pseudo_voigt", lambda x, h, c, fw, eta: np.zeros_like(x), raising=False
+    )
+
+    out_dir = tmp_path / "out"
+    cfg = {
+        "output_dir": str(out_dir),
+        "peaks": [
+            {"center": 1.0, "height": 1.0, "fwhm": 1.0, "eta": 0.5}
+        ],
+        "solver": "classic",
+        "unc_method": "asymptotic",
+    }
+
+    n_ok, total = run_batch([str(f)], cfg, compute_uncertainty=True)
+    n_fail = total - n_ok
+    assert n_fail == 0
+
+    # Uncertainty file should be produced
+    stem = Path(f).stem
+    assert (out_dir / f"{stem}_uncertainty.txt").exists()
+

--- a/tests/test_batch_unc_method_strict_unknown.py
+++ b/tests/test_batch_unc_method_strict_unknown.py
@@ -1,0 +1,51 @@
+import types
+import pytest
+import numpy as np
+from pathlib import Path
+from batch.runner import run_batch
+
+
+def _fake_fit_ctx(x, y):
+    peak = types.SimpleNamespace(center=1.0, height=1.0, fwhm=1.0, eta=0.5, lock_center=False, lock_width=False)
+    return {
+        "fit_ok": True,
+        "theta": np.array([1.0, 1.0, 1.0, 0.5]),
+        "x": x,
+        "y": y,
+        "x_fit": list(x),
+        "y_fit": list(y),
+        "peaks": [peak],
+        "peaks_out": [peak],
+        "baseline": np.zeros_like(x),
+        "mode": "add",
+        "residual_fn": lambda th: y - 0.0 * x,
+        "jacobian": np.eye(4),
+        "predict_full": lambda th, x=x: np.zeros_like(x),
+        "rmse": 0.0,
+        "dof": max(1, x.size - 4),
+    }
+
+
+def test_unknown_unc_method_raises(tmp_path, monkeypatch):
+    f = tmp_path / "toy.txt"
+    f.write_text("0 0\n1 1\n2 0\n")
+
+    from core import data_io as dio
+    monkeypatch.setattr(dio, "load_xy", lambda p: (np.array([0.0,1.0,2.0]), np.array([0.0,1.0,0.0])))
+
+    from core import signals
+    monkeypatch.setattr(signals, "als_baseline", lambda y, **k: np.zeros_like(y))
+
+    from core import fit_api
+    monkeypatch.setattr(fit_api, "run_fit_consistent", lambda *a, **k: _fake_fit_ctx(*a[:2]))
+
+    out_dir = tmp_path / "out"
+    cfg = {
+        "output_dir": str(out_dir),
+        "peaks": [{"center":1.0,"height":1.0,"fwhm":1.0,"eta":0.5}],
+        "solver": "classic",
+        "unc_method": "totally-unknown-method",
+    }
+
+    with pytest.raises(ValueError):
+        run_batch([str(f)], cfg, compute_uncertainty=True, unc_method=None, log=lambda m: None)


### PR DESCRIPTION
## Summary
- Introduce `route_uncertainty` to dispatch asymptotic, bootstrap, and bayesian confidence intervals with no fallback
- Refactor batch runner to use the new router and compute finite-difference Jacobians when needed
- Gracefully log uncertainty failures while still raising on unknown methods
- Add regression tests ensuring unknown batch uncertainty methods raise `ValueError` and the finite-difference Jacobian path is exercised

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9a66e222483308601fc2e203a9740