### PR TITLE
Add polynomial baseline with UI defaults and persistence

### DIFF
--- a/core/signals.py
+++ b/core/signals.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 import numpy as np
 
+__all__ = ["als_baseline", "snr_estimate", "polynomial_baseline"]
+
 
 def als_baseline(y: np.ndarray, lam: float = 1e5, p: float = 0.001,
                  niter: int = 10, tol: float = 0.0) -> np.ndarray:
@@ -49,3 +51,64 @@ def snr_estimate(y: np.ndarray) -> float:
     if noise == 0:
         return float("inf")
     return float(signal / noise)
+
+
+def polynomial_baseline(
+    x: np.ndarray,
+    y: np.ndarray,
+    *,
+    degree: int = 2,
+    mask: np.ndarray | None = None,
+    weights: np.ndarray | None = None,
+    normalize_x: bool = True,
+) -> np.ndarray:
+    """Weighted least-squares polynomial baseline on ``(x, y)``.
+
+    Fits on masked points if ``mask`` is provided and returns the baseline
+    evaluated on the full ``x`` domain.  ``weights`` apply to the fit region
+    only.  When ``normalize_x`` is ``True`` the fit is performed on scaled
+    coordinates in ``[-1, 1]`` for improved numerical stability.
+    """
+
+    import numpy as np
+
+    x = np.asarray(x, float)
+    y = np.asarray(y, float)
+
+    if degree < 0:
+        raise ValueError("degree must be >= 0")
+
+    if mask is not None:
+        m = np.asarray(mask, bool)
+        x_fit, y_fit = x[m], y[m]
+        w_fit = None if weights is None else np.asarray(weights, float)[m]
+    else:
+        x_fit, y_fit = x, y
+        w_fit = None if weights is None else np.asarray(weights, float)
+
+    if normalize_x:
+        x_min = float(x_fit.min())
+        x_max = float(x_fit.max())
+        span = max(x_max - x_min, 1e-12)
+
+        def scale(xx):
+            return 2.0 * (xx - x_min) / span - 1.0
+
+        xf = scale(x_fit)
+        x_all = scale(x)
+    else:
+        xf = x_fit
+        x_all = x
+
+    V = np.vander(xf, N=degree + 1, increasing=True)
+    if w_fit is not None:
+        w = np.sqrt(np.clip(w_fit, 0.0, np.inf))[:, None]
+        A = V * w
+        b = y_fit[:, None] * w
+    else:
+        A = V
+        b = y_fit[:, None]
+
+    beta, *_ = np.linalg.lstsq(A, b, rcond=None)
+    V_all = np.vander(x_all, N=degree + 1, increasing=True)
+    return (V_all @ beta).ravel()

--- a/tests/test_als_unchanged_with_poly_present.py
+++ b/tests/test_als_unchanged_with_poly_present.py
@@ -1,0 +1,20 @@
+import numpy as np
+from core import models, peaks, signals, fit_api
+
+
+def test_als_unchanged_with_poly_present():
+    x = np.linspace(-5, 5, 201)
+    seeds = [peaks.Peak(0.0, 1.0, 1.0, 0.5)]
+    y = models.pv_sum(x, seeds)
+    mask = np.ones_like(x, bool)
+    cfg = {
+        "solver": "modern_vp",
+        "baseline": {"method": "als", "lam": 1e5, "p": 0.001, "niter": 10, "thresh": 0.0},
+        "baseline_uses_fit_range": True,
+    }
+    baseline = signals.als_baseline(y, lam=1e5, p=0.001, niter=10, tol=0.0)
+    res_manual = fit_api.run_fit_consistent(x, y, seeds, cfg, baseline, "add", mask)
+    res_auto = fit_api.run_fit_consistent(x, y, seeds, cfg, None, "add", mask)
+    assert np.allclose(res_manual["baseline"], baseline)
+    assert np.allclose(res_auto["baseline"], baseline)
+    assert np.allclose(res_manual["theta"], res_auto["theta"])

--- a/tests/test_baseline_method_persistence.py
+++ b/tests/test_baseline_method_persistence.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import pathlib
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from ui import app  # noqa: E402
+
+headless = os.environ.get("DISPLAY", "") == "" and os.name != "nt"
+if headless:
+    pytest.skip("Skipping GUI tests in headless environment", allow_module_level=True)
+
+tk = pytest.importorskip("tkinter")
+
+
+def test_baseline_method_persistence(tmp_path, monkeypatch):
+    cfg_path = tmp_path / "cfg.json"
+    monkeypatch.setattr(app, "CONFIG_PATH", cfg_path)
+
+    root1 = tk.Tk()
+    root1.withdraw()
+    a1 = app.PeakFitApp(root1)
+    a1.base_method_var.set("polynomial")
+    a1.poly_degree_var.set(4)
+    a1.poly_norm_var.set(False)
+    a1.save_baseline_default()
+    root1.destroy()
+
+    root2 = tk.Tk()
+    root2.withdraw()
+    a2 = app.PeakFitApp(root2)
+    assert a2.base_method_var.get() == "polynomial"
+    assert a2.poly_degree_var.get() == 4
+    assert bool(a2.poly_norm_var.get()) is False
+    root2.destroy()

--- a/tests/test_batch_vs_single_polynomial.py
+++ b/tests/test_batch_vs_single_polynomial.py
@@ -1,0 +1,59 @@
+import numpy as np
+import pandas as pd
+from core import fit_api, models, peaks, signals
+from batch import runner
+
+
+def test_batch_vs_single_polynomial(tmp_path):
+    x = np.linspace(-5, 5, 201)
+    seeds = [
+        peaks.Peak(-0.8, 1.0, 0.6, 0.5),
+        peaks.Peak(0.9, 0.8, 0.5, 0.4),
+    ]
+    y = models.pv_sum(x, seeds)
+    mask = np.ones_like(x, bool)
+    fpath = tmp_path / "spec.csv"
+    np.savetxt(fpath, np.column_stack([x, y]), delimiter=",")
+
+    cfg_single = {
+        "solver": "modern_vp",
+        "solver_loss": "linear",
+        "solver_weight": "none",
+        "perf_seed_all": True,
+        "baseline": {"method": "polynomial", "degree": 3, "normalize_x": True},
+        "baseline_uses_fit_range": True,
+    }
+    baseline = signals.polynomial_baseline(x, y, degree=3, normalize_x=True)
+    res_single = fit_api.run_fit_consistent(
+        x,
+        y,
+        seeds,
+        cfg_single,
+        baseline,
+        "add",
+        mask,
+        rng_seed=123,
+    )
+
+    cfg_batch = {
+        "peaks": [p.__dict__ for p in seeds],
+        "solver": "modern_vp",
+        "mode": "add",
+        "baseline": {"method": "polynomial", "degree": 3, "normalize_x": True},
+        "baseline_uses_fit_range": True,
+        "output_dir": str(tmp_path),
+        "output_base": "batch",
+        "save_traces": False,
+        "perf_seed_all": True,
+    }
+    runner.run([str(fpath)], cfg_batch)
+
+    df = pd.read_csv(tmp_path / "batch_fit.csv").sort_values("peak")
+    theta_batch = []
+    for row in df.itertuples():
+        theta_batch.extend([row.center, row.height, row.fwhm, row.eta])
+    theta_batch = np.asarray(theta_batch)
+
+    assert np.allclose(res_single["theta"], theta_batch, atol=1e-6, rtol=1e-6)
+    assert np.isnan(df["als_lam"]).all()
+    assert (tmp_path / f"{fpath.stem}_uncertainty.txt").exists()

--- a/tests/test_determinism_polynomial.py
+++ b/tests/test_determinism_polynomial.py
@@ -1,0 +1,19 @@
+import numpy as np
+from core import models, peaks, fit_api
+
+
+def test_determinism_polynomial():
+    x = np.linspace(-3, 3, 121)
+    seeds = [peaks.Peak(-0.5, 1.0, 0.6, 0.3), peaks.Peak(0.7, 0.8, 0.5, 0.4)]
+    y = models.pv_sum(x, seeds)
+    mask = np.ones_like(x, bool)
+    cfg = {
+        "solver": "modern_vp",
+        "perf_seed_all": True,
+        "baseline": {"method": "polynomial", "degree": 2, "normalize_x": True},
+        "baseline_uses_fit_range": True,
+    }
+    res1 = fit_api.run_fit_consistent(x, y, seeds, cfg, None, "add", mask, rng_seed=1)
+    res2 = fit_api.run_fit_consistent(x, y, seeds, cfg, None, "add", mask, rng_seed=1)
+    assert np.allclose(res1["baseline"], res2["baseline"])
+    assert np.allclose(res1["theta"], res2["theta"])

--- a/tests/test_poly_baseline_core.py
+++ b/tests/test_poly_baseline_core.py
@@ -1,0 +1,18 @@
+import numpy as np
+from core.signals import polynomial_baseline
+
+
+def test_quadratic_recovery():
+    x = np.linspace(-1, 1, 201)
+    truth = 0.5 + 1.2 * x + 0.3 * x**2
+    baseline = polynomial_baseline(x, truth, degree=2, normalize_x=True)
+    assert np.max(np.abs(baseline - truth)) < 1e-6
+
+
+def test_degree_zero_one():
+    x = np.linspace(-2, 2, 11)
+    y0 = np.full_like(x, 2.0)
+    assert np.allclose(polynomial_baseline(x, y0, degree=0), 2.0)
+    y1 = 3.0 + 2.0 * x
+    base1 = polynomial_baseline(x, y1, degree=1)
+    assert np.allclose(base1, y1)

--- a/tests/test_poly_baseline_fit_range.py
+++ b/tests/test_poly_baseline_fit_range.py
@@ -1,0 +1,12 @@
+import numpy as np
+from core.signals import polynomial_baseline
+
+
+def test_poly_baseline_fit_range_matches_polyfit():
+    x = np.linspace(-1, 1, 101)
+    y = 1.0 + 2.0 * x
+    mask = np.abs(x) <= 0.2  # center 40%
+    baseline = polynomial_baseline(x, y, degree=1, mask=mask, normalize_x=True)
+    coef = np.polyfit(x[mask], y[mask], 1)
+    truth = np.polyval(coef, x)
+    assert np.allclose(baseline, truth, rtol=1e-6, atol=1e-6)


### PR DESCRIPTION
## Summary
- add weighted polynomial baseline helper
- support ALS or polynomial baselines in engine and batch runner
- expose baseline method and polynomial settings in GUI with persisted defaults
- add regression tests for polynomial baseline and persistence

## Testing
- `pytest tests/test_poly_baseline_core.py tests/test_poly_baseline_fit_range.py tests/test_batch_vs_single_polynomial.py tests/test_baseline_method_persistence.py tests/test_als_unchanged_with_poly_present.py tests/test_determinism_polynomial.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9e92ed2288330a406d0351de1e28d