### PR TITLE
Polynomial baseline caching and degree guardrails

### DIFF
--- a/core/signals.py
+++ b/core/signals.py
@@ -61,7 +61,8 @@ def polynomial_baseline(
     mask: np.ndarray | None = None,
     weights: np.ndarray | None = None,
     normalize_x: bool = True,
-) -> np.ndarray:
+    return_used_degree: bool = False,
+) -> np.ndarray | tuple[np.ndarray, int]:
     """Weighted least-squares polynomial baseline on ``(x, y)``.
 
     Fits on masked points if ``mask`` is provided and returns the baseline
@@ -75,9 +76,6 @@ def polynomial_baseline(
     x = np.asarray(x, float)
     y = np.asarray(y, float)
 
-    if degree < 0:
-        raise ValueError("degree must be >= 0")
-
     if mask is not None:
         m = np.asarray(mask, bool)
         x_fit, y_fit = x[m], y[m]
@@ -86,12 +84,15 @@ def polynomial_baseline(
         x_fit, y_fit = x, y
         w_fit = None if weights is None else np.asarray(weights, float)
 
+    max_deg = max(0, int(x_fit.size) - 1)
+    used_deg = min(max(0, int(degree)), max_deg)
+
     if normalize_x:
-        x_min = float(x_fit.min())
-        x_max = float(x_fit.max())
+        x_min = float(x_fit.min()) if x_fit.size else 0.0
+        x_max = float(x_fit.max()) if x_fit.size else 1.0
         span = max(x_max - x_min, 1e-12)
 
-        def scale(xx):
+        def scale(xx: np.ndarray) -> np.ndarray:
             return 2.0 * (xx - x_min) / span - 1.0
 
         xf = scale(x_fit)
@@ -100,7 +101,7 @@ def polynomial_baseline(
         xf = x_fit
         x_all = x
 
-    V = np.vander(xf, N=degree + 1, increasing=True)
+    V = np.vander(xf, N=used_deg + 1, increasing=True)
     if w_fit is not None:
         w = np.sqrt(np.clip(w_fit, 0.0, np.inf))[:, None]
         A = V * w
@@ -110,5 +111,6 @@ def polynomial_baseline(
         b = y_fit[:, None]
 
     beta, *_ = np.linalg.lstsq(A, b, rcond=None)
-    V_all = np.vander(x_all, N=degree + 1, increasing=True)
-    return (V_all @ beta).ravel()
+    V_all = np.vander(x_all, N=used_deg + 1, increasing=True)
+    baseline = (V_all @ beta).ravel()
+    return (baseline, used_deg) if return_used_degree else baseline

--- a/tests/test_export_als_fields_nan_with_poly.py
+++ b/tests/test_export_als_fields_nan_with_poly.py
@@ -1,0 +1,56 @@
+import numpy as np
+import pandas as pd
+from core import fit_api, models, peaks, signals, data_io
+
+
+def test_export_als_fields_nan_with_poly(tmp_path):
+    x = np.linspace(-5, 5, 201)
+    seed_peak = peaks.Peak(0.0, 1.0, 1.0, 0.5)
+    y = models.pv_sum(x, [seed_peak])
+    mask = np.ones_like(x, bool)
+    cfg = {
+        "solver": "modern_vp",
+        "baseline": {"method": "polynomial", "degree": 2, "normalize_x": True},
+        "baseline_uses_fit_range": True,
+    }
+    baseline = signals.polynomial_baseline(x, y, degree=2, normalize_x=True)
+    res = fit_api.run_fit_consistent(x, y, [seed_peak], cfg, baseline, "add", mask)
+    peaks_out = res["peaks_out"]
+    areas = [models.pv_area(p.height, p.fwhm, p.eta) for p in peaks_out]
+    total = sum(areas) or 1.0
+    records = []
+    for i, (p, a) in enumerate(zip(peaks_out, areas), start=1):
+        records.append(
+            {
+                "file": "sample",
+                "peak": i,
+                "center": p.center,
+                "height": p.height,
+                "fwhm": p.fwhm,
+                "eta": p.eta,
+                "lock_width": p.lock_width,
+                "lock_center": p.lock_center,
+                "area": a,
+                "area_pct": 100.0 * a / total,
+                "rmse": res["rmse"],
+                "fit_ok": res["fit_ok"],
+                "mode": "add",
+                "fit_xmin": x[0],
+                "fit_xmax": x[-1],
+                "solver_choice": "modern_vp",
+                "use_baseline": True,
+                "baseline_mode": "add",
+                "baseline_uses_fit_range": True,
+                "als_lam": np.nan,
+                "als_p": np.nan,
+                "als_niter": np.nan,
+                "als_thresh": np.nan,
+            }
+        )
+    csv = data_io.build_peak_table(records)
+    out = tmp_path / "peaks.csv"
+    out.write_text(csv, encoding="utf-8")
+    df = pd.read_csv(out)
+    for col in ["als_lam", "als_p", "als_niter", "als_thresh"]:
+        assert col in df.columns
+        assert df[col].isna().all()

--- a/tests/test_fit_api_unknown_baseline_method_raises.py
+++ b/tests/test_fit_api_unknown_baseline_method_raises.py
@@ -1,0 +1,13 @@
+import numpy as np
+import pytest
+from core import fit_api, peaks
+
+
+def test_fit_api_unknown_baseline_method_raises():
+    x = np.linspace(-1, 1, 11)
+    y = np.zeros_like(x)
+    seeds = [peaks.Peak(0.0, 1.0, 1.0, 0.5)]
+    cfg = {"baseline": {"method": "nope"}}
+    mask = np.ones_like(x, bool)
+    with pytest.raises(ValueError, match="Unknown baseline method"):
+        fit_api.run_fit_consistent(x, y, seeds, cfg, None, "add", mask)

--- a/tests/test_poly_baseline_caching.py
+++ b/tests/test_poly_baseline_caching.py
@@ -1,0 +1,57 @@
+import numpy as np
+from core import signals
+from infra import performance
+
+
+def compute_cached(x, y, deg, norm, mask, cache):
+    key = None
+    if performance.cache_baseline_enabled():
+        slice_key = None
+        if mask is not None and np.any(mask):
+            slice_key = (float(x[mask][0]), float(x[mask][-1]))
+        key = (hash(y.tobytes()), "poly", int(deg), bool(norm), slice_key)
+    if key is not None and key in cache:
+        return cache[key]
+    base = signals.polynomial_baseline(
+        x, y, degree=deg, mask=mask, normalize_x=norm
+    )
+    if key is not None:
+        cache[key] = base
+    return base
+
+
+def test_poly_baseline_caching(monkeypatch):
+    x = np.linspace(-5, 5, 101)
+    y = x ** 2
+    cache = {}
+    calls = {"n": 0}
+
+    orig = signals.polynomial_baseline
+
+    def wrapped(*args, **kwargs):
+        calls["n"] += 1
+        return orig(*args, **kwargs)
+
+    monkeypatch.setattr(signals, "polynomial_baseline", wrapped)
+    performance.set_cache_baseline(True)
+
+    compute_cached(x, y, 2, True, None, cache)
+    assert calls["n"] == 1
+    compute_cached(x, y, 2, True, None, cache)
+    assert calls["n"] == 1
+
+    compute_cached(x, y, 3, True, None, cache)
+    assert calls["n"] == 2
+
+    compute_cached(x, y, 3, False, None, cache)
+    assert calls["n"] == 3
+
+    mask1 = (x > -1) & (x < 1)
+    compute_cached(x, y, 3, False, mask1, cache)
+    assert calls["n"] == 4
+    compute_cached(x, y, 3, False, mask1, cache)
+    assert calls["n"] == 4
+
+    mask2 = (x > -2) & (x < 2)
+    compute_cached(x, y, 3, False, mask2, cache)
+    assert calls["n"] == 5

--- a/tests/test_poly_degree_guard.py
+++ b/tests/test_poly_degree_guard.py
@@ -1,0 +1,18 @@
+import numpy as np
+from core import signals
+
+def test_poly_degree_guard():
+    x = np.linspace(0, 10, 5)
+    y = x ** 2
+    mask = np.zeros_like(x, dtype=bool)
+    mask[:3] = True  # only three points available
+    baseline, used = signals.polynomial_baseline(
+        x,
+        y,
+        degree=5,
+        mask=mask,
+        normalize_x=True,
+        return_used_degree=True,
+    )
+    assert used == mask.sum() - 1
+    assert baseline.shape == x.shape

--- a/ui/app.py
+++ b/ui/app.py
@@ -2044,13 +2044,35 @@ class PeakFitApp:
         elif method == "polynomial":
             deg = int(self.poly_degree_var.get())
             norm_x = bool(self.poly_norm_var.get())
-            try:
-                self.baseline = signals.polynomial_baseline(
-                    self.x, self.y_raw, degree=deg, mask=mask, normalize_x=norm_x
-                )
-            except Exception as e:
-                messagebox.showwarning("Baseline", f"Polynomial baseline failed: {e}")
-                self.baseline = np.zeros_like(self.y_raw)
+            key = None
+            if performance.cache_baseline_enabled():
+                slice_key = None
+                if mask is not None and np.any(mask):
+                    slice_key = (float(self.x[mask][0]), float(self.x[mask][-1]))
+                key = (hash(self.y_raw.tobytes()), "poly", int(deg), bool(norm_x), slice_key)
+            if key is not None and key in self._baseline_cache:
+                self.baseline = self._baseline_cache[key]
+            else:
+                try:
+                    base, used_deg = signals.polynomial_baseline(
+                        self.x,
+                        self.y_raw,
+                        degree=deg,
+                        mask=mask,
+                        normalize_x=norm_x,
+                        return_used_degree=True,
+                    )
+                    if used_deg != deg:
+                        self.poly_degree_var.set(used_deg)
+                        self.status_var.set(
+                            f"Polynomial baseline: degree reduced to {used_deg} due to fit-range points."
+                        )
+                    self.baseline = base
+                    if key is not None:
+                        self._baseline_cache[key] = base
+                except Exception as e:
+                    messagebox.showwarning("Baseline", f"Polynomial baseline failed: {e}")
+                    self.baseline = np.zeros_like(self.y_raw)
         else:
             messagebox.showwarning("Baseline", f"Unknown baseline method: {method}")
             self.baseline = np.zeros_like(self.y_raw)


### PR DESCRIPTION
## Summary
- Clamp polynomial baseline degree to available data points and optionally report the used degree
- Cache polynomial baselines in the UI with cache-key parity to ALS and surface status notice when degree is reduced
- Add tests for polynomial caching, degree guard, export ALS-field NaNs, and unknown baseline method

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9f2a97fc0833094ef2c20be77bd60