### PR TITLE
Improve uncertainty worker usage and UI

### DIFF
--- a/ui/app.py
+++ b/ui/app.py
@@ -3405,6 +3405,7 @@ class PeakFitApp:
                     "x_all": x_fit,
                     "y_all": y_fit,
                     "unc_workers": workers,
+                    "progress_cb": lambda msg: self.log_threadsafe(str(msg)),
                     "abort_event": abort_evt,
                 }
 
@@ -3443,6 +3444,7 @@ class PeakFitApp:
                     "x_all": x_fit,
                     "y_all": y_fit,
                     "unc_workers": workers,
+                    "progress_cb": lambda msg: self.log_threadsafe(str(msg)),
                     "abort_event": abort_evt,
                 }
                 out = core_uncertainty.bayesian_ci(


### PR DESCRIPTION
## Summary
- cap uncertainty workers to CPU count, thread bootstrap/bayesian band evals, and free CuPy memory
- parallelize Bayesian MCMC with emcee pool and robust abort handling
- expose bootstrap draw/seed controls with config helper and pass abort events to uncertainty backends

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba442023a8833086ac8a68497ffdff