### PR TITLE
Pass solver and locks to uncertainty; harden bootstrap and Bayesian routines

### DIFF
--- a/core/uncertainty.py
+++ b/core/uncertainty.py
@@ -427,11 +427,11 @@ def bootstrap_ci(
     t0 = float(time.time())
     theta = np.asarray(theta, float)
     residual_in = np.asarray(residual, float)
-    jacobian = np.asarray(jacobian, float)  # unused, kept for API parity
     if center_residuals:
         r = residual_in - residual_in.mean()
     else:
         r = residual_in.copy()
+    J = np.asarray(jacobian, float)
 
     fit = fit_ctx or {}
     x_all = fit.get("x_all", x_all)
@@ -440,13 +440,21 @@ def bootstrap_ci(
         raise ValueError("x_all and y_all required for residual bootstrap")
     x_all = np.asarray(x_all, float)
     y_all = np.asarray(y_all, float)
-    y_hat = np.asarray(y_all, float) - residual_in
+    # Prefer model to compute y_hat to avoid loss-mode mismatch
+    if callable(predict_full):
+        try:
+            y_hat = np.asarray(predict_full(theta), float)
+        except Exception:
+            y_hat = np.asarray(y_all, float) - residual_in
+    else:
+        y_hat = np.asarray(y_all, float) - residual_in
 
     peaks_obj = fit.get("peaks")
     if not peaks_obj:
         ymodel = predict_full if callable(predict_full) else (lambda _th: np.asarray(y_all, float))
-        res_asym = asymptotic_ci(theta, residual_in, jacobian, ymodel, alpha=alpha)
+        res_asym = asymptotic_ci(theta, residual_in, J, ymodel, alpha=alpha)
         diag = dict(res_asym.diagnostics)
+        # normalize: no refits, just asymptotic
         diag.update({
             "aborted": False,
             "reason": "no-peaks",
@@ -482,9 +490,15 @@ def bootstrap_ci(
         mode = (fit_ctx.get("mode") if fit_ctx else "add") or "add"
         baseline = fit_ctx.get("baseline") if fit_ctx else None
         solver = (fit_ctx.get("solver") if fit_ctx else None) or "classic"
+        # propagate sharing flags (only used by lmfit_vp)
+        share_fwhm = bool((fit_ctx or {}).get("lmfit_share_fwhm", False))
+        share_eta = bool((fit_ctx or {}).get("lmfit_share_eta", False))
 
         def refit(theta_init, locked_mask, bounds, x, y):
             cfg = {"solver": solver, "mode": mode, "peaks": peaks_to_dicts(peaks_obj)}
+            if str(solver).lower().startswith("lmfit"):
+                cfg["lmfit_share_fwhm"] = share_fwhm
+                cfg["lmfit_share_eta"] = share_eta
             res = _fit_api.run_fit_consistent(
                 x,
                 y,
@@ -500,6 +514,16 @@ def bootstrap_ci(
 
     theta0 = np.asarray(fit.get("theta0", theta), float)
     P = theta.size
+    free_mask = np.ones(P, dtype=bool)
+    if locked_mask is not None:
+        free_mask = ~np.asarray(locked_mask, bool)
+    Jf = J[:, free_mask] if J.ndim == 2 else None
+    # If LMFIT ties parameters across peaks, linear fallback is unsafe
+    if bool((fit_ctx or {}).get("lmfit_share_fwhm")) or bool((fit_ctx or {}).get("lmfit_share_eta")):
+        Jf = None  # disable linear fallback under sharing
+    linear_fallbacks = 0
+    # mild LM damping used for linear fallback
+    linear_lambda = None
 
     # ---- Bootstrap resampling loop (abort-aware with progress pulses) ----
     # Existing variables used below (expected from prior code):
@@ -518,6 +542,7 @@ def bootstrap_ci(
     next_pulse_at = 0
     pulse_step = max(1, int(n_boot // 20))
     last_pulse_t = time.monotonic()
+    jitter_scale = float((fit_ctx or {}).get("bootstrap_jitter", 0.02))  # 2% default
     for b in range(int(n_boot)):
         # Abort quickly if requested
         if abort_evt is not None and getattr(abort_evt, "is_set", None):
@@ -539,9 +564,14 @@ def bootstrap_ci(
 
         # Residual resample
         idx = rng.integers(0, n, size=n)
-        y_star = y_hat + r[idx]
+        r_star = r[idx]
+        y_star = y_hat + r_star
         try:
-            ref_res = refit(theta0, locked_mask, bounds, x_all, y_star)
+            theta_init = theta0.copy()
+            if jitter_scale > 0 and np.any(free_mask):
+                step = jitter_scale * np.maximum(np.abs(theta_init), 1.0)
+                theta_init[free_mask] += rng.normal(0.0, step[free_mask])
+            ref_res = refit(theta_init, locked_mask, bounds, x_all, y_star)
             if isinstance(ref_res, tuple):
                 th_new, ok = ref_res
             else:
@@ -550,9 +580,65 @@ def bootstrap_ci(
                 T_list.append(th_new)
                 n_success += 1
             else:
-                n_fail += 1
+                # Damped GN fallback: (JᵀJ + λI)Δ = Jᵀ r*
+                used = False
+                if Jf is not None and Jf.size and np.sum(free_mask) > 0:
+                    try:
+                        AtA = Jf.T @ Jf
+                        rhs = Jf.T @ r_star
+                        lam = 5e-2 * (np.trace(AtA) / max(1, AtA.shape[0]))
+                        if not np.isfinite(lam) or lam <= 0:
+                            lam = 1e-3
+                        linear_lambda = float(lam)
+                        AtA += lam * np.eye(AtA.shape[0])
+                        delta_f = np.linalg.solve(AtA, rhs)
+                        th_lin = theta0.copy()
+                        th_lin[free_mask] = th_lin[free_mask] + delta_f
+                        if bounds is not None:
+                            lo, hi = bounds
+                            if lo is not None:
+                                th_lin = np.maximum(th_lin, lo)
+                            if hi is not None:
+                                th_lin = np.minimum(th_lin, hi)
+                        if np.all(np.isfinite(th_lin)):
+                            T_list.append(th_lin)
+                            n_success += 1
+                            linear_fallbacks += 1
+                            used = True
+                    except Exception:
+                        pass
+                if not used:
+                    n_fail += 1
         except Exception:
-            n_fail += 1
+            # Try linear fallback also on exceptions
+            used = False
+            if Jf is not None and Jf.size and np.sum(free_mask) > 0:
+                try:
+                    AtA = Jf.T @ Jf
+                    rhs = Jf.T @ r_star
+                    lam = 5e-2 * (np.trace(AtA) / max(1, AtA.shape[0]))
+                    if not np.isfinite(lam) or lam <= 0:
+                        lam = 1e-3
+                    linear_lambda = float(lam)
+                    AtA += lam * np.eye(AtA.shape[0])
+                    delta_f = np.linalg.solve(AtA, rhs)
+                    th_lin = theta0.copy()
+                    th_lin[free_mask] = th_lin[free_mask] + delta_f
+                    if bounds is not None:
+                        lo, hi = bounds
+                        if lo is not None:
+                            th_lin = np.maximum(th_lin, lo)
+                        if hi is not None:
+                            th_lin = np.minimum(th_lin, hi)
+                    if np.all(np.isfinite(th_lin)):
+                        T_list.append(th_lin)
+                        n_success += 1
+                        linear_fallbacks += 1
+                        used = True
+                except Exception:
+                    pass
+            if not used:
+                n_fail += 1
 
     if len(T_list):
         theta_succ = np.vstack(T_list)
@@ -650,10 +736,13 @@ def bootstrap_ci(
         "n_boot": int(n_boot),
         "n_success": int(n_success),
         "n_fail": int(n_fail),
+        "n_linear_fallback": int(linear_fallbacks),
+        "linear_lambda": float(linear_lambda) if linear_lambda is not None else None,
         "seed": seed,
         "pct_at_bounds": pct_at_bounds,
         "aborted": bool(aborted),
         "runtime_s": float(time.time() - t0),
+        "theta_jitter_scale": float(jitter_scale),
         "band_source": "bootstrap-percentile" if band is not None else None,
         "band_reason": band_reason,
     }
@@ -707,10 +796,28 @@ def bayesian_ci(
         raise RuntimeError("Bayesian method requires emcee>=3") from e
 
     theta_hat = np.asarray(theta_hat, float)
-    locked = np.asarray(locked_mask, bool) if locked_mask is not None else np.zeros(theta_hat.size, bool)
-    free_idx = np.where(~locked)[0]
+    # Optional tying (LMFIT "share FWHM/eta"): collapse tied params to one free scalar
+    share_fwhm = bool((fit_ctx or {}).get("lmfit_share_fwhm", False))
+    share_eta = bool((fit_ctx or {}).get("lmfit_share_eta", False))
+    locked_eff = locked_mask.copy() if locked_mask is not None else np.zeros(theta_hat.size, bool)
+    tie_groups: list[tuple[int, list[int]]] = []
+    if share_fwhm:
+        idx = [4 * i + 2 for i in range(theta_hat.size // 4)]
+        leader = next((j for j in idx if not locked_eff[j]), idx[0])
+        for j in idx:
+            if j != leader:
+                locked_eff[j] = True
+        tie_groups.append((leader, idx))
+    if share_eta:
+        idx = [4 * i + 3 for i in range(theta_hat.size // 4)]
+        leader = next((j for j in idx if not locked_eff[j]), idx[0])
+        for j in idx:
+            if j != leader:
+                locked_eff[j] = True
+        tie_groups.append((leader, idx))
+    free_idx = np.where(~np.asarray(locked_eff, bool))[0]
+    P_free = int(free_idx.size)
     th_free = theta_hat[free_idx]
-    P_free = th_free.size
     if P_free == 0:
         free_idx = np.array([], int)
 
@@ -754,10 +861,19 @@ def bayesian_ci(
             lp += math.log(2.0/ math.pi) - math.log(s*(1.0 + (sigma/s)**2)) + math.log(1.0/max(sigma,1e-300))
         return lp
 
-    def log_likelihood(th_f, log_sigma):
+    def _project_full(th_f):
         th_full = theta_hat.copy()
-        th_full[free_idx] = th_f
+        if P_free:
+            th_full[free_idx] = th_f
+        # replicate leaders to their tied group members
+        for leader, group in tie_groups:
+            th_full[group] = th_full[leader]
+        return th_full
+
+    def log_likelihood(th_f, log_sigma):
+        th_full = _project_full(th_f)
         mu = pred(th_full)
+        if not np.all(np.isfinite(mu)): return -np.inf
         if mu.shape != y_all.shape: return -np.inf
         sigma = np.exp(log_sigma)
         if not np.isfinite(sigma) or sigma <= 0: return -np.inf
@@ -772,8 +888,15 @@ def bayesian_ci(
         return lp + log_likelihood(th_f, log_sigma)
 
     dim = P_free + 1
+    # Sane defaults if caller passes 0/None
+    if n_burn is None or n_burn <= 0:
+        n_burn = 1000
+    if n_steps is None or n_steps <= 0:
+        n_steps = 4000
+    n_burn = int(n_burn)
+    n_steps = int(n_steps)
     if n_walkers is None:
-        n_walkers = max(4*dim, 16)
+        n_walkers = max(4 * dim, 16)
     rng = np.random.default_rng(seed)
     # Optional progress + abort
     abort_evt = None
@@ -841,16 +964,44 @@ def bayesian_ci(
         if pool is not None:
             pool.shutdown(wait=True, cancel_futures=True)
 
+    # Early abort/minimal mode: skip heavy post-processing
+    if abort_evt is not None and getattr(abort_evt, "is_set", lambda: False)():
+        return UncertaintyResult(
+            method="bayesian",
+            label="Bayesian (MCMC)",
+            stats={},
+            diagnostics={"aborted": True, "n_draws": 0, "band_source": None},
+            band=None,
+        )
+
     chain = sampler.get_chain(discard=n_burn, thin=thin)
     acc_frac = float(np.mean(sampler.acceptance_fraction))
     if chain.ndim != 3:
         chain = np.asarray(chain)
         chain = chain.reshape((n_walkers, -1, dim))
-    n_samp = chain.shape[1]*n_walkers
+    n_post = chain.shape[1]
+    if n_post <= 0:
+        # Avoid "index -1" crashes when burn==total or abort mid-burn
+        return UncertaintyResult(
+            method="bayesian",
+            label="Bayesian (MCMC)",
+            stats={},
+            diagnostics={"aborted": True, "n_draws": 0, "accept_frac_mean": acc_frac, "band_source": None},
+            band=None,
+        )
+    n_samp = n_post * n_walkers
 
-    if n_samp < 2:
-        raise RuntimeError("insufficient MCMC draws")
     flat = chain.reshape(-1, dim)
+    flat = flat[np.all(np.isfinite(flat), axis=1)]
+    n_samp = flat.shape[0]
+    if n_samp < 2:
+        return UncertaintyResult(
+            method="bayesian",
+            label="Bayesian (MCMC)",
+            stats={},
+            diagnostics={"aborted": True, "n_draws": 0, "accept_frac_mean": acc_frac, "band_source": None},
+            band=None,
+        )
     th_draws = flat[:, :P_free]
     log_sigma_draws = flat[:, -1]
     sigma_draws = np.exp(log_sigma_draws)
@@ -858,6 +1009,9 @@ def bayesian_ci(
     T = np.tile(theta_hat, (th_draws.shape[0], 1))
     if P_free:
         T[:, free_idx] = th_draws
+    # Apply ties on all draws
+    for leader, group in tie_groups:
+        T[:, group] = T[:, [leader]]
     mean = T.mean(axis=0)
     sd = T.std(axis=0, ddof=1)
     qlo = np.quantile(T, 0.025, axis=0); qhi = np.quantile(T, 0.975, axis=0)
@@ -872,10 +1026,8 @@ def bayesian_ci(
         "p97.5": float(np.quantile(sigma_draws, 0.975)),
     }
 
-    # Skip emcee's get_autocorr_time() to avoid noisy warnings (short chains).
-    chains = chain
-    ess_min = ess_autocorr(chains)
-    rhat_max = rhat_split(chains)
+    # Keep diagnostics light; no ESS/Rhat to avoid stalls
+    ess_min, rhat_max = float("nan"), float("nan")
     diag = {
         "n_draws": int(n_samp),
         "ess_min": float(ess_min),
@@ -886,61 +1038,11 @@ def bayesian_ci(
         "band_source": None,
     }
 
-    band = None
-    if return_band and predict_full is not None and x_all is not None and n_samp >= BAYES_BAND_MIN_DRAWS:
-        max_use = min(n_samp, 4096)
-        sel = np.linspace(0, n_samp-1, max_use, dtype=int)
-        T_sel = T[sel]
-        sig_sel = sigma_draws[sel]
-
-        def _eval_one(idx: int) -> np.ndarray:
-            t_i = T_sel[idx]
-            s_i = float(sig_sel[idx])
-            mu = pred(t_i)
-            try:
-                import cupy as cp  # type: ignore
-                if isinstance(mu, cp.ndarray):
-                    mu = cp.asnumpy(mu)
-            except Exception:
-                pass
-            mu = np.asarray(mu, float)
-            eps = rng.normal(0.0, s_i, size=mu.shape)
-            return mu + eps
-
-        Y_list: List[np.ndarray] = []
-        # Thread predictive draws; cap workers
-        workers_req = 0
-        try:
-            workers_req = int((fit_ctx or {}).get("unc_workers", 0))
-        except Exception:
-            workers_req = 0
-        w = max(0, min(workers_req, (os.cpu_count() or 1)))
-        if w > 0:
-            with ThreadPoolExecutor(max_workers=w) as ex:
-                futs = {ex.submit(_eval_one, int(i)): int(i) for i in range(len(sel))}
-                for f in as_completed(futs):
-                    Y_list.append(f.result())
-        else:
-            for i in range(len(sel)):
-                Y_list.append(_eval_one(int(i)))
-
-        Y = np.vstack(Y_list)
-        lo = np.quantile(Y, 0.025, axis=0)
-        hi = np.quantile(Y, 0.975, axis=0)
-        band = (np.asarray(x_all, float), lo, hi)
-        diag["band_source"] = "bayes-posterior-predictive"
-        diag["band_backend"] = "numpy"
-        diag["workers_used"] = int(w)
-        try:
-            import cupy as cp  # type: ignore
-            cp.get_default_memory_pool().free_all_blocks()
-        except Exception:
-            pass
-
+    # Never compute bands for Bayesian (disabled)
     return UncertaintyResult(
         method="bayesian",
         label="Bayesian (MCMC)",
         stats=stats,
         diagnostics=diag,
-        band=band,
+        band=None,
     )

--- a/tests/test_bayesian_basic.py
+++ b/tests/test_bayesian_basic.py
@@ -25,9 +25,8 @@ def test_bayesian_basic(two_peak_data, tmp_path):
     assert res.get("method") != "NotAvailable"
     stats = res["param_stats"]
     assert np.any(stats["std"] > 0)
-    band = res["band"]
-    x, lo, hi = band["x"], band["lo"], band["hi"]
-    assert len(x) == len(lo) == len(hi)
+    # Bands are disabled for Bayesian uncertainty
+    assert res.get("band") is None
     paths = data_io.derive_export_paths(str(tmp_path / "out.csv"))
     data_io.write_uncertainty_csv(paths["unc_csv"], res)
     data_io.write_uncertainty_txt(paths["unc_txt"], res)

--- a/ui/app.py
+++ b/ui/app.py
@@ -726,6 +726,14 @@ class PeakFitApp:
         self.cfg.setdefault("unc_workers", 0)
         self.cfg.setdefault("last_template_name", self.cfg.get("auto_apply_template_name", ""))
         self.cfg.setdefault("export_unc_wide", False)
+        self.cfg.setdefault("unc_alpha", 0.05)
+        self.cfg.setdefault("unc_center_resid", True)
+        self.cfg.setdefault("bootstrap_jitter", 0.02)
+        self.cfg.setdefault("bayes_walkers", 0)
+        self.cfg.setdefault("bayes_burn", 1000)
+        self.cfg.setdefault("bayes_steps", 4000)
+        self.cfg.setdefault("bayes_thin", 1)
+        self.cfg.setdefault("bayes_prior_sigma", "half_cauchy")
         save_config(self.cfg)
         self.root.title("Interactive Peak Fit (pseudo-Voigt)")
 
@@ -861,7 +869,6 @@ class PeakFitApp:
         self._last_unc_locks: List[Dict[str, bool]] = []
 
         self.current_file: Optional[Path] = None
-        self.show_ci_band.trace_add("write", self._toggle_ci_band)
         self._abort_evt = threading.Event()
 
         # Uncertainty and performance controls
@@ -874,6 +881,11 @@ class PeakFitApp:
             unc_label = "Asymptotic"
         self.unc_method = tk.StringVar(value=unc_label)
         self.unc_method_var = self.unc_method
+        # ensure band toggle reflects current method on startup
+        try:
+            self._on_uncertainty_method_changed()
+        except Exception:
+            pass
         self.unc_workers_var = tk.IntVar(value=int(self.cfg.get("unc_workers", 0)))
         self.unc_workers_var.trace_add("write", lambda *_: self._on_unc_workers_change())
         self.perf_numba = tk.BooleanVar(value=bool(self.cfg.get("perf_numba", False)))
@@ -886,12 +898,23 @@ class PeakFitApp:
         self.perf_cache_baseline.trace_add("write", lambda *_: self.apply_performance())
         self.perf_seed_all.trace_add("write", lambda *_: self.apply_performance())
         self.perf_max_workers.trace_add("write", lambda *_: self.apply_performance())
+        self.alpha_var = tk.DoubleVar(value=float(self.cfg.get("unc_alpha", 0.05)))
+        self.center_resid_var = tk.BooleanVar(value=bool(self.cfg.get("unc_center_resid", True)))
+        self.bootstrap_jitter_var = tk.DoubleVar(value=100.0 * float(self.cfg.get("bootstrap_jitter", 0.02)))
+
+        self.bayes_walkers_var = tk.IntVar(value=int(self.cfg.get("bayes_walkers", 0)))  # 0 => auto
+        self.bayes_burn_var = tk.IntVar(value=int(self.cfg.get("bayes_burn", 1000)))
+        self.bayes_steps_var = tk.IntVar(value=int(self.cfg.get("bayes_steps", 4000)))
+        self.bayes_thin_var = tk.IntVar(value=int(self.cfg.get("bayes_thin", 1)))
+        self.bayes_prior_var = tk.StringVar(value=str(self.cfg.get("bayes_prior_sigma", "half_cauchy")))
         self.seed_var = tk.StringVar(value="")
         self.gpu_chunk_var = tk.IntVar(value=262144)
 
         # UI
         self._build_ui()
         self._new_figure()
+        # attach after axes are created to avoid early refresh calls
+        self.show_ci_band.trace_add("write", self._toggle_ci_band)
         self._update_template_info()
         self.apply_performance()
 
@@ -1353,6 +1376,33 @@ class PeakFitApp:
         self.chk_ci_band.pack(anchor="w", padx=4)
         self.ci_toggle = self.chk_ci_band
         self._set_ci_toggle_state(False)
+
+        # Extra uncertainty controls
+        unc_frame = ttk.Frame(unc_box)
+        unc_frame.pack(fill=tk.X, pady=2)
+        r = 0
+        ttk.Label(unc_frame, text="Jitter %").grid(row=r, column=0, sticky="e")
+        self._jitter_entry = ttk.Entry(unc_frame, textvariable=self.bootstrap_jitter_var, width=6)
+        self._jitter_entry.grid(row=r, column=1, sticky="w")
+        r += 1
+        ttk.Label(unc_frame, text="CI α").grid(row=r, column=0, sticky="e")
+        ttk.Entry(unc_frame, textvariable=self.alpha_var, width=6).grid(row=r, column=1, sticky="w")
+        ttk.Checkbutton(unc_frame, text="Center residuals", variable=self.center_resid_var).grid(row=r, column=2, sticky="w")
+        r += 1
+
+        bay = ttk.LabelFrame(unc_frame, text="Bayesian (no band)")
+        bay.grid(row=r, column=0, columnspan=4, sticky="we", pady=(4, 0))
+        ttk.Label(bay, text="Walkers").grid(row=0, column=0, sticky="e")
+        ttk.Entry(bay, textvariable=self.bayes_walkers_var, width=6).grid(row=0, column=1, sticky="w")
+        ttk.Label(bay, text="Burn-in").grid(row=0, column=2, sticky="e")
+        ttk.Entry(bay, textvariable=self.bayes_burn_var, width=6).grid(row=0, column=3, sticky="w")
+        ttk.Label(bay, text="Steps").grid(row=1, column=0, sticky="e")
+        ttk.Entry(bay, textvariable=self.bayes_steps_var, width=6).grid(row=1, column=1, sticky="w")
+        ttk.Label(bay, text="Thin").grid(row=1, column=2, sticky="e")
+        ttk.Entry(bay, textvariable=self.bayes_thin_var, width=6).grid(row=1, column=3, sticky="w")
+        ttk.Label(bay, text="σ prior").grid(row=2, column=0, sticky="e")
+        ttk.Combobox(bay, textvariable=self.bayes_prior_var, width=12,
+                     values=("half_cauchy", "half_normal"), state="readonly").grid(row=2, column=1, sticky="w")
         self._update_unc_widgets()
         self._on_uncertainty_method_changed()
 
@@ -1662,10 +1712,21 @@ class PeakFitApp:
 
     def _on_uncertainty_method_changed(self, *_):
         sel = str(self.unc_method_var.get()).lower()
-        self._set_ci_toggle_state(True)
-        if "asym" not in sel:
+        is_bayes = ("bayes" in sel)
+        # toggle availability
+        self._set_ci_toggle_state(not is_bayes)
+        try:
+            state = ("normal" if "bootstrap" in sel else "disabled")
+            for w in (self._jitter_entry,):
+                w.configure(state=state)
+        except Exception:
+            pass
+        if is_bayes:
+            # hard-disable for Bayesian
+            self.show_ci_band_var.set(False)
             self.ci_band = None
             self.refresh_plot()
+        # for asymptotic/bootstrap the checkbox remains user-controlled
 
 
     def on_abort_clicked(self):
@@ -3353,6 +3414,33 @@ class PeakFitApp:
             import os
             workers_req = int(self.cfg.get("unc_workers", 0))
             workers = max(0, min(workers_req, (os.cpu_count() or 1)))
+
+            # Build locked mask (center/fwhm locks) for bootstrap/Bayesian refits
+            locked_mask = np.zeros(theta.size, dtype=bool)
+            for i, pk in enumerate(self.peaks):
+                if bool(getattr(pk, "lock_center", False)):
+                    locked_mask[4 * i + 0] = True
+                if bool(getattr(pk, "lock_width", False)):
+                    locked_mask[4 * i + 2] = True
+
+            alpha = min(max(float(self.alpha_var.get()), 1e-6), 0.5)
+            jitter_pct = max(0.0, min(float(self.bootstrap_jitter_var.get()), 50.0))
+            walkers = max(0, int(self.bayes_walkers_var.get() or 0))
+            burn = max(0, int(self.bayes_burn_var.get()))
+            steps = max(1, int(self.bayes_steps_var.get()))
+            thin = max(1, int(self.bayes_thin_var.get()))
+            self.alpha_var.set(alpha); self.bootstrap_jitter_var.set(jitter_pct)
+            self.bayes_walkers_var.set(walkers); self.bayes_burn_var.set(burn)
+            self.bayes_steps_var.set(steps); self.bayes_thin_var.set(thin)
+
+            self._cfg_set("unc_alpha", alpha)
+            self._cfg_set("unc_center_resid", bool(self.center_resid_var.get()))
+            self._cfg_set("bootstrap_jitter", jitter_pct / 100.0)
+            self._cfg_set("bayes_walkers", walkers)
+            self._cfg_set("bayes_burn", burn)
+            self._cfg_set("bayes_steps", steps)
+            self._cfg_set("bayes_thin", thin)
+            self._cfg_set("bayes_prior_sigma", str(self.bayes_prior_var.get()))
             if method == "asymptotic":
                 res = self._run_asymptotic_uncertainty()
                 if abort_evt.is_set():
@@ -3414,10 +3502,16 @@ class PeakFitApp:
                     "predict_full": predict_full,
                     "x_all": x_fit,
                     "y_all": y_fit,
+                    "solver": self.solver_choice.get(),
+                    # propagate sharing flags for LMFIT VP
+                    "lmfit_share_fwhm": bool(self.lmfit_share_fwhm.get()),
+                    "lmfit_share_eta":  bool(self.lmfit_share_eta.get()),
                     "peaks": self.peaks,
+                    "locked_mask": locked_mask,
                     "unc_workers": workers,
                     "progress_cb": lambda msg: self.log_threadsafe(str(msg)),
                     "abort_event": abort_evt,
+                    "bootstrap_jitter": jitter_pct / 100.0,
                 }
 
                 out = core_uncertainty.bootstrap_ci(
@@ -3427,11 +3521,14 @@ class PeakFitApp:
                     predict_full=predict_full,
                     x_all=x_fit,
                     y_all=y_fit,
+                    locked_mask=locked_mask,
                     fit_ctx=fit_ctx,
                     n_boot=n_boot,
                     seed=seed_val,
                     workers=workers,
                     return_band=bool(self.show_ci_band_var.get()),
+                    alpha=alpha,
+                    center_residuals=bool(self.center_resid_var.get()),
                 )
                 if abort_evt.is_set():
                     return {"label": "Aborted", "stats": {}, "diagnostics": {"aborted": True}}
@@ -3455,7 +3552,11 @@ class PeakFitApp:
                     "predict_full": predict_full,
                     "x_all": x_fit,
                     "y_all": y_fit,
+                    "solver": self.solver_choice.get(),
+                    "lmfit_share_fwhm": bool(self.lmfit_share_fwhm.get()),
+                    "lmfit_share_eta":  bool(self.lmfit_share_eta.get()),
                     "peaks": self.peaks,
+                    "locked_mask": locked_mask,
                     "unc_workers": workers,
                     "progress_cb": lambda msg: self.log_threadsafe(str(msg)),
                     "abort_event": abort_evt,
@@ -3468,7 +3569,14 @@ class PeakFitApp:
                     y_all=y_fit,
                     residual_fn=(lambda th: resid_fn(th)),
                     fit_ctx=fit_ctx,
-                    return_band=bool(self.show_ci_band_var.get()),
+                    locked_mask=locked_mask,
+                    # Force off: bands for MCMC are disabled
+                    return_band=False,
+                    n_walkers=(walkers or None),
+                    n_burn=burn,
+                    n_steps=steps,
+                    thin=thin,
+                    prior_sigma=str(self.bayes_prior_var.get()),
                 )
                 if abort_evt.is_set():
                     return {"label": "Aborted", "stats": {}, "diagnostics": {"aborted": True}}
@@ -4017,6 +4125,8 @@ class PeakFitApp:
         self.refresh_plot()
 
     def refresh_plot(self):
+        if not hasattr(self, "ax") or self.ax is None:
+            return
         LW_RAW, LW_BASE, LW_CORR, LW_COMP, LW_FIT = 1.0, 1.0, 0.9, 0.8, 1.2
         self.ax.clear()
         self.ax.set_xlabel(format_axis_label_inline(self.x_label_var.get(), self.x_label_auto_math.get()))


### PR DESCRIPTION
## Summary
- propagate solver choice and locked-mask from the UI into uncertainty contexts
- make bootstrap resampling robust: derive y_hat from model, add Jacobian-based fallback, report linear fallback count
- make Bayesian sampler safer: enforce default burn-in/steps, handle aborts early, skip heavy diagnostics
- disable bootstrap linear fallback when LMFIT shares parameters and increase fallback damping
- tie shared Bayesian parameters, drop invalid draws, and seed jittered refits for more realistic bootstrap variance
- disable uncertainty bands for Bayesian and make "Show uncertainty band" checkbox method-aware
- expose bootstrap jitter, CI alpha, residual centering, and Bayesian sampler settings in the UI and persist them
- clamp UI inputs, treat jitter as percent, and disable jitter control outside Bootstrap; guard Bayesian likelihood for non-finite outputs and recompute sample counts after filtering
- delay uncertainty-band trace wiring until axes exist and guard refresh_plot when axes are missing to prevent startup errors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba59adb7cc8330bd58139067b48b1f