### PR TITLE
feat: expand bootstrap and Bayesian uncertainty options

### DIFF
--- a/core/uncertainty.py
+++ b/core/uncertainty.py
@@ -518,9 +518,12 @@ def bootstrap_ci(
     if locked_mask is not None:
         free_mask = ~np.asarray(locked_mask, bool)
     Jf = J[:, free_mask] if J.ndim == 2 else None
+    allow_linear = bool((fit_ctx or {}).get("allow_linear_fallback", True))
     # If LMFIT ties parameters across peaks, linear fallback is unsafe
     if bool((fit_ctx or {}).get("lmfit_share_fwhm")) or bool((fit_ctx or {}).get("lmfit_share_eta")):
         Jf = None  # disable linear fallback under sharing
+    if not allow_linear:
+        Jf = None  # globally disable if requested
     linear_fallbacks = 0
     # mild LM damping used for linear fallback
     linear_lambda = None

--- a/ui/app.py
+++ b/ui/app.py
@@ -857,8 +857,18 @@ class PeakFitApp:
         self.modern_min_fwhm = tk.BooleanVar(value=True)
         self.lmfit_algo = tk.StringVar(value="least_squares")
         self.lmfit_maxfev = tk.IntVar(value=20000)
-        self.lmfit_share_fwhm = tk.BooleanVar(value=False)
-        self.lmfit_share_eta = tk.BooleanVar(value=False)
+        self.cfg.setdefault("lmfit_share_fwhm", False)
+        self.cfg.setdefault("lmfit_share_eta", False)
+        self.lmfit_share_fwhm = tk.BooleanVar(value=bool(self.cfg.get("lmfit_share_fwhm", False)))
+        self.lmfit_share_eta = tk.BooleanVar(value=bool(self.cfg.get("lmfit_share_eta", False)))
+        self.lmfit_share_fwhm.trace_add(
+            "write",
+            lambda *_: self._cfg_set("lmfit_share_fwhm", bool(self.lmfit_share_fwhm.get())),
+        )
+        self.lmfit_share_eta.trace_add(
+            "write",
+            lambda *_: self._cfg_set("lmfit_share_eta", bool(self.lmfit_share_eta.get())),
+        )
         self.snr_text = tk.StringVar(value="S/N: --")
 
         self.ci_band = None
@@ -1363,7 +1373,11 @@ class PeakFitApp:
                 pass
         _toggle_boot_row()
         try:
-            self.unc_method_combo.bind("<<ComboboxSelected>>", lambda _e: _toggle_boot_row())
+            self.unc_method_combo.bind(
+                "<<ComboboxSelected>>",
+                lambda _e: (self._on_uncertainty_method_changed(), _toggle_boot_row()),
+                add="+",
+            )
         except Exception:
             pass
 
@@ -1385,6 +1399,33 @@ class PeakFitApp:
         self._jitter_entry = ttk.Entry(unc_frame, textvariable=self.bootstrap_jitter_var, width=6)
         self._jitter_entry.grid(row=r, column=1, sticky="w")
         r += 1
+        # Bootstrap refit solver override
+        ttk.Label(unc_frame, text="Refit solver").grid(row=r, column=0, sticky="e")
+        self.boot_solver_choice = tk.StringVar(
+            value=str(self.cfg.get("unc_boot_solver", self.solver_choice.get()))
+        )
+        # Only offer LMFIT if actually available
+        def _available_solvers():
+            keys = list(SOLVER_LABELS.keys())
+            if not getattr(self, "has_lmfit", False):
+                keys = [k for k in keys if not str(k).lower().startswith("lmfit")]
+            return tuple(keys)
+        self._boot_solver_cb = ttk.Combobox(
+            unc_frame,
+            textvariable=self.boot_solver_choice,
+            width=22,
+            state="readonly",
+            values=_available_solvers(),
+        )
+        self._boot_solver_cb.grid(row=r, column=1, columnspan=2, sticky="w")
+        self._boot_solver_cb.bind(
+            "<<ComboboxSelected>>",
+            lambda _e: (
+                self._cfg_set("unc_boot_solver", self.boot_solver_choice.get()),
+                self._update_bootstrap_tie_widgets(),
+            ),
+        )
+        r += 1
         ttk.Label(unc_frame, text="CI α").grid(row=r, column=0, sticky="e")
         ttk.Entry(unc_frame, textvariable=self.alpha_var, width=6).grid(row=r, column=1, sticky="w")
         ttk.Checkbutton(unc_frame, text="Center residuals", variable=self.center_resid_var).grid(row=r, column=2, sticky="w")
@@ -1403,6 +1444,20 @@ class PeakFitApp:
         ttk.Label(bay, text="σ prior").grid(row=2, column=0, sticky="e")
         ttk.Combobox(bay, textvariable=self.bayes_prior_var, width=12,
                      values=("half_cauchy", "half_normal"), state="readonly").grid(row=2, column=1, sticky="w")
+        r += 1
+
+        # --- Bootstrap ties (visible + enabled only when Bootstrap + LMFIT refit solver) ---
+        ties = ttk.LabelFrame(unc_frame, text="Bootstrap ties (LMFIT only)")
+        ties.grid(row=r, column=0, columnspan=4, sticky="we", pady=(4, 0))
+        self.chk_share_fwhm = ttk.Checkbutton(
+            ties, text="Share FWHM across peaks", variable=self.lmfit_share_fwhm
+        )
+        self.chk_share_fwhm.grid(row=0, column=0, sticky="w", padx=2, pady=1)
+        self.chk_share_eta = ttk.Checkbutton(
+            ties, text="Share η across peaks", variable=self.lmfit_share_eta
+        )
+        self.chk_share_eta.grid(row=0, column=1, sticky="w", padx=2, pady=1)
+
         self._update_unc_widgets()
         self._on_uncertainty_method_changed()
 
@@ -1713,21 +1768,45 @@ class PeakFitApp:
     def _on_uncertainty_method_changed(self, *_):
         sel = str(self.unc_method_var.get()).lower()
         is_bayes = ("bayes" in sel)
-        # toggle availability
+        # toggle availability of band checkbox
         self._set_ci_toggle_state(not is_bayes)
-        try:
-            state = ("normal" if "bootstrap" in sel else "disabled")
-            for w in (self._jitter_entry,):
-                w.configure(state=state)
-        except Exception:
-            pass
+        # enable/disable jitter & bootstrap-only controls
+        state = ("normal" if "bootstrap" in sel else "disabled")
+        for w in (getattr(self, "_jitter_entry", None), getattr(self, "_boot_solver_cb", None)):
+            if w is not None:
+                try:
+                    w.configure(state=state)
+                except Exception:
+                    pass
         if is_bayes:
             # hard-disable for Bayesian
             self.show_ci_band_var.set(False)
             self.ci_band = None
             self.refresh_plot()
+        # refresh Bootstrap tie widgets (enable only for Bootstrap + LMFIT refit solver)
+        self._update_bootstrap_tie_widgets()
         # for asymptotic/bootstrap the checkbox remains user-controlled
 
+
+    def _update_bootstrap_tie_widgets(self):
+        try:
+            sel = str(self.unc_method_var.get()).lower()
+            is_boot = ("bootstrap" in sel)
+            solver = (
+                self.boot_solver_choice.get()
+                if hasattr(self, "boot_solver_choice")
+                else self.solver_choice.get()
+            )
+            is_lmfit = str(solver).lower().startswith("lmfit") and bool(getattr(self, "has_lmfit", False))
+            state = "normal" if (is_boot and is_lmfit) else "disabled"
+            for w in (
+                getattr(self, "chk_share_fwhm", None),
+                getattr(self, "chk_share_eta", None),
+            ):
+                if w is not None:
+                    w.configure(state=state)
+        except Exception:
+            pass
 
     def on_abort_clicked(self):
         try:
@@ -3493,6 +3572,16 @@ class PeakFitApp:
                         total = total + base_fit
                     return total
 
+                # choose refit solver: override if user selected one for bootstrap
+                boot_solver = self.cfg.get("unc_boot_solver", self.solver_choice.get())
+                # Guard: if LMFIT not installed but override points to it, fall back
+                if not getattr(self, "has_lmfit", False) and str(boot_solver).lower().startswith("lmfit"):
+                    boot_solver = self.solver_choice.get()
+                    try:
+                        # keep UI in sync
+                        self.boot_solver_choice.set(boot_solver)
+                    except Exception:
+                        pass
                 fit_ctx = {
                     "x": x_fit,
                     "y": y_fit,
@@ -3502,7 +3591,7 @@ class PeakFitApp:
                     "predict_full": predict_full,
                     "x_all": x_fit,
                     "y_all": y_fit,
-                    "solver": self.solver_choice.get(),
+                    "solver": boot_solver,
                     # propagate sharing flags for LMFIT VP
                     "lmfit_share_fwhm": bool(self.lmfit_share_fwhm.get()),
                     "lmfit_share_eta":  bool(self.lmfit_share_eta.get()),
@@ -3512,6 +3601,8 @@ class PeakFitApp:
                     "progress_cb": lambda msg: self.log_threadsafe(str(msg)),
                     "abort_event": abort_evt,
                     "bootstrap_jitter": jitter_pct / 100.0,
+                    # important: turn off linear JᵀJ fallback to avoid unrealistically tight spreads
+                    "allow_linear_fallback": False,
                 }
 
                 out = core_uncertainty.bootstrap_ci(
@@ -3561,6 +3652,21 @@ class PeakFitApp:
                     "progress_cb": lambda msg: self.log_threadsafe(str(msg)),
                     "abort_event": abort_evt,
                 }
+                # sensible bounds for MCMC to prevent runaway widths/etas
+                n_pk = len(self.peaks)
+                P = 4 * n_pk
+                lo = np.full(P, -np.inf, float); hi = np.full(P, np.inf, float)
+                xlo, xhi = float(np.min(x_fit)), float(np.max(x_fit))
+                lo[0::4] = xlo;  hi[0::4] = xhi                     # centers
+                lo[1::4] = 0.0;                                     # heights >= 0
+                # use corrected y without ambiguous array truthiness
+                y_corr = y_fit if add_mode or base_fit is None else (y_fit - base_fit)
+                yscale = float(np.nanmax(y_corr))
+                hi[1::4] = max(1.0, 1.5 * yscale)                   # height cap
+                lo[2::4] = max(1e-3, float(self.classic_fwhm_min.get() if hasattr(self, "classic_fwhm_min") else 1e-2))
+                hi[2::4] = max(1.0, xhi - xlo)                      # width ≤ window
+                lo[3::4] = 0.0;  hi[3::4] = 1.0                     # 0 ≤ eta ≤ 1
+
                 out = core_uncertainty.bayesian_ci(
                     theta_hat=theta,
                     model=predict_full,
@@ -3577,6 +3683,7 @@ class PeakFitApp:
                     n_steps=steps,
                     thin=thin,
                     prior_sigma=str(self.bayes_prior_var.get()),
+                    bounds=(lo, hi),
                 )
                 if abort_evt.is_set():
                     return {"label": "Aborted", "stats": {}, "diagnostics": {"aborted": True}}
@@ -4087,19 +4194,27 @@ class PeakFitApp:
                 )
                 saved_unc.append(str(txt_path))
 
-                # Band, if present (asymptotic and any method that provides it)
-                band = unc_norm.get("band")
-                if band is not None:
-                    xb, lob, hib = band
+                # also export prediction band for any method if present (asymptotic & bootstrap)
+                band_tup = self._band_tuple_from(unc_norm)
+                if band_tup is not None:
+                    bx, blo, bhi = band_tup
                     band_csv = export_base.with_name(export_base.name + "_uncertainty_band.csv")
-                    with band_csv.open("w", newline="", encoding="utf-8") as fh:
-                        w = csv.writer(fh, lineterminator="\n")
-                        w.writerow(["x", "y_lo95", "y_hi95"])
-                        for xi, lo, hi in zip(xb, lob, hib):
-                            if not (math.isfinite(float(xi)) and math.isfinite(float(lo)) and math.isfinite(float(hi))):
-                                continue
-                            w.writerow([float(xi), float(lo), float(hi)])
-                    saved_unc.append(str(band_csv))
+                    try:
+                        import csv, math
+                        # dynamic header reflects chosen alpha
+                        try:
+                            ci_pct = int(round(100 * (1.0 - float(self.alpha_var.get()))))
+                        except Exception:
+                            ci_pct = 95
+                        with band_csv.open("w", newline="", encoding="utf-8") as fh:
+                            w = csv.writer(fh, lineterminator="\n")
+                            w.writerow(["x", f"y_lo{ci_pct}", f"y_hi{ci_pct}"])
+                            for xi, lo, hi in zip(bx, blo, bhi):
+                                if math.isfinite(float(xi)) and math.isfinite(float(lo)) and math.isfinite(float(hi)):
+                                    w.writerow([float(xi), float(lo), float(hi)])
+                        saved_unc.append(str(band_csv))
+                    except Exception:
+                        pass
 
                 self.log(f"Exported uncertainty ({label}).")
                 for pth in saved_unc:


### PR DESCRIPTION
## Summary
- add refit solver override and live method binding for bootstrap
- bound Bayesian sampling parameters and export bootstrap bands
- disable linear fallback in bootstrap and respect the flag in core
- persist LMFIT share FWHM/η defaults and expose Bootstrap tie controls
- fix prediction-band export path and Bayesian bound calculation
- limit bootstrap solver choices to installed solvers and fallback when LMFIT missing
- label exported bands using current confidence interval

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb2b33dcc88330a8efa409099770c5