### PR TITLE
Add deterministic parallel bootstrap draws with GPU band support

### DIFF
--- a/batch/runner.py
+++ b/batch/runner.py
@@ -450,6 +450,11 @@ def run_batch(
                         "relabel_by_center": True,
                     }
                 )
+                fit_ctx.update({
+                    "unc_workers": unc_workers if unc_workers > 0 else None,
+                    "unc_band_workers": int(config.get("unc_band_workers", unc_workers)) if unc_workers > 0 else None,
+                    "unc_use_gpu": bool(config.get("unc_use_gpu", False)),
+                })
 
                 from core import fit_api as _fit_api
 

--- a/core/uncertainty_router.py
+++ b/core/uncertainty_router.py
@@ -160,6 +160,7 @@ def route_uncertainty(
         jitter = _norm_jitter(ctx.get("bootstrap_jitter", ctx.get("jitter", 0.0)))
         ctx["bootstrap_jitter"] = jitter
         ctx["strict_refit"] = True
+        ctx["unc_use_gpu"] = bool(ctx.get("unc_use_gpu", False))
         # Jitter travels through fit_ctx so the engine can normalize/inspect it.
         return unc.bootstrap_ci(
             theta=theta_hat,

--- a/tests/test_bootstrap_band_cpu_parallel_matches.py
+++ b/tests/test_bootstrap_band_cpu_parallel_matches.py
@@ -1,0 +1,69 @@
+import numpy as np
+
+from core.uncertainty import bootstrap_ci
+
+
+def test_band_cpu_parallel_matches_sequential():
+    x = np.linspace(0, 1, 200)
+    theta = np.array([0.2, 0.5, 0.1, 0.3])
+    y = np.sin(2 * np.pi * x)
+    resid = y - y.mean()
+    J = np.ones((x.size, theta.size))
+
+    def refit(th0, locked_mask, bounds, x_in, y_in):
+        return np.asarray(th0, float), True
+
+    def model(th):
+        return np.sin(2 * np.pi * x)
+
+    fit_ctx = {
+        "x_all": x,
+        "y_all": y,
+        "baseline": None,
+        "mode": "add",
+        "refit": refit,
+        "strict_refit": True,
+        "bootstrap_jitter": 0.05,
+        "peaks": [object()],
+    }
+
+    r_seq = bootstrap_ci(
+        theta,
+        resid,
+        J,
+        predict_full=model,
+        x_all=x,
+        y_all=y,
+        fit_ctx=fit_ctx,
+        n_boot=64,
+        seed=7,
+        workers=0,
+        alpha=0.1,
+        center_residuals=True,
+        return_band=True,
+    )
+
+    fit_ctx_p = dict(fit_ctx)
+    fit_ctx_p["unc_band_workers"] = 4
+    r_par = bootstrap_ci(
+        theta,
+        resid,
+        J,
+        predict_full=model,
+        x_all=x,
+        y_all=y,
+        fit_ctx=fit_ctx_p,
+        n_boot=64,
+        seed=7,
+        workers=0,
+        alpha=0.1,
+        center_residuals=True,
+        return_band=True,
+    )
+
+    assert r_seq.band is not None and r_par.band is not None
+    _, lo_seq, hi_seq = r_seq.band
+    _, lo_par, hi_par = r_par.band
+    np.testing.assert_allclose(lo_seq, lo_par, rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(hi_seq, hi_par, rtol=1e-12, atol=1e-12)
+    assert r_par.diagnostics.get("band_workers_used") == 4

--- a/tests/test_bootstrap_band_gpu_backend.py
+++ b/tests/test_bootstrap_band_gpu_backend.py
@@ -1,0 +1,59 @@
+import importlib.util
+import numpy as np
+import pytest
+
+from core.uncertainty import bootstrap_ci
+
+cp_spec = importlib.util.find_spec("cupy")
+
+
+@pytest.mark.skipif(cp_spec is None, reason="CuPy not installed")
+def test_band_backend_cupy_when_enabled(monkeypatch):
+    import importlib
+
+    cp = importlib.import_module("cupy")
+
+    x = np.linspace(0, 1, 128)
+    theta = np.array([0.3, 1.0, 0.2, 0.5])
+    rng = np.random.default_rng(0)
+    y_cpu = np.sin(2 * np.pi * x) + 0.01 * rng.normal(size=x.size)
+    resid = y_cpu - y_cpu.mean()
+    J = np.ones((x.size, theta.size))
+
+    def refit(th0, locked_mask, bounds, x_in, y_in):
+        return np.asarray(th0, float), True
+
+    def predict_full(th):
+        return cp.asarray(np.sin(2 * np.pi * x))
+
+    fit_ctx = {
+        "x_all": x,
+        "y_all": y_cpu,
+        "baseline": None,
+        "mode": "add",
+        "refit": refit,
+        "strict_refit": True,
+        "bootstrap_jitter": 0.05,
+        "unc_use_gpu": True,
+        "unc_band_workers": 0,
+        "peaks": [object()],
+    }
+    monkeypatch.setenv("PEAKFIT_USE_GPU", "1")
+
+    res = bootstrap_ci(
+        theta=theta,
+        residual=resid,
+        jacobian=J,
+        predict_full=predict_full,
+        x_all=x,
+        y_all=y_cpu,
+        fit_ctx=fit_ctx,
+        n_boot=64,
+        seed=123,
+        workers=0,
+        alpha=0.1,
+        center_residuals=True,
+        return_band=True,
+    )
+    assert res.band is not None
+    assert res.diagnostics.get("band_backend") == "cupy"

--- a/tests/test_bootstrap_parallel_determinism.py
+++ b/tests/test_bootstrap_parallel_determinism.py
@@ -1,0 +1,66 @@
+import numpy as np
+
+from core.uncertainty import bootstrap_ci
+
+
+def test_bootstrap_parallel_is_deterministic_with_seed():
+    x = np.linspace(0, 1, 64)
+    theta = np.array([0.3, 1.0, 0.2, 0.5])
+    rng = np.random.default_rng(0)
+    y = np.sin(2 * np.pi * x) + 0.01 * rng.normal(size=x.size)
+    resid = y - y.mean()
+    J = np.ones((x.size, theta.size))
+
+    def refit(th0, locked_mask, bounds, x_in, y_in):
+        # Deterministic: return jittered init as the "fit" with ok=True
+        return np.asarray(th0, float), True
+
+    fit_ctx = {
+        "x_all": x,
+        "y_all": y,
+        "baseline": None,
+        "mode": "add",
+        "refit": refit,
+        "strict_refit": True,
+        "bootstrap_jitter": 0.05,
+        "peaks": [object()],
+    }
+
+    r_serial = bootstrap_ci(
+        theta,
+        resid,
+        J,
+        predict_full=lambda th: y,
+        x_all=x,
+        y_all=y,
+        fit_ctx=fit_ctx,
+        n_boot=64,
+        seed=42,
+        workers=None,
+        alpha=0.1,
+        center_residuals=True,
+        return_band=False,
+    )
+
+    r_parallel = bootstrap_ci(
+        theta,
+        resid,
+        J,
+        predict_full=lambda th: y,
+        x_all=x,
+        y_all=y,
+        fit_ctx=fit_ctx,
+        n_boot=64,
+        seed=42,
+        workers=4,
+        alpha=0.1,
+        center_residuals=True,
+        return_band=False,
+    )
+
+    assert r_serial.diagnostics["n_success"] == 64
+    assert r_parallel.diagnostics["n_success"] == 64
+    np.testing.assert_allclose(
+        r_serial.stats["p0"]["est"],
+        r_parallel.stats["p0"]["est"],
+    )

--- a/ui/app.py
+++ b/ui/app.py
@@ -3573,6 +3573,8 @@ class PeakFitApp:
                 "x_all": x_fit,
                 "y_all": y_fit,
                 "unc_workers": workers,
+                "unc_band_workers": workers,
+                "unc_use_gpu": bool(getattr(self, "use_gpu_var", None) and self.use_gpu_var.get()),
                 "solver": boot_solver,
                 "strict_refit": True,
                 "bootstrap_jitter": jitter_val,
@@ -3632,6 +3634,8 @@ class PeakFitApp:
                 "x_all": x_fit,
                 "y_all": y_fit,
                 "unc_workers": workers,
+                "unc_band_workers": workers,
+                "unc_use_gpu": bool(getattr(self, "use_gpu_var", None) and self.use_gpu_var.get()),
             }
             out = core_uncertainty.bayesian_ci(
                 theta_hat=theta,


### PR DESCRIPTION
## Summary
- parallelize bootstrap draws with deterministic per-draw RNG streams and add optional GPU-backed quantile bands
- propagate bootstrap worker, band worker, and GPU flags through the router, batch runner, and GUI contexts
- add regression tests covering deterministic draws, GPU backend selection, and CPU parallel band agreement

## Testing
- `pytest -q tests/test_bootstrap_parallel_determinism.py tests/test_bootstrap_band_gpu_backend.py tests/test_bootstrap_band_cpu_parallel_matches.py`


------
https://chatgpt.com/codex/tasks/task_e_68d8cdcbb8a88330a72e0b1c95e597e7