### PR TITLE
Enforce bootstrap refit failures and jitter diagnostics

### DIFF
--- a/core/uncertainty_router.py
+++ b/core/uncertainty_router.py
@@ -160,6 +160,10 @@ def route_uncertainty(
         jitter = _norm_jitter(ctx.get("bootstrap_jitter", ctx.get("jitter", 0.0)))
         ctx["bootstrap_jitter"] = jitter
         ctx["strict_refit"] = True
+        if "unc_workers" not in ctx and "workers" in locals():
+            ctx["unc_workers"] = workers
+        if "unc_band_workers" not in ctx:
+            ctx["unc_band_workers"] = ctx.get("unc_workers", None)
         ctx["unc_use_gpu"] = bool(ctx.get("unc_use_gpu", False))
         # Jitter travels through fit_ctx so the engine can normalize/inspect it.
         return unc.bootstrap_ci(

--- a/tests/test_bootstrap_batch_refit_visible_errors.py
+++ b/tests/test_bootstrap_batch_refit_visible_errors.py
@@ -1,0 +1,44 @@
+import numpy as np
+
+from core.uncertainty import bootstrap_ci
+
+
+def test_batch_refit_errors_exposed():
+    x = np.linspace(0, 1, 64)
+    theta = np.array([0.3, 1.0, 0.2, 0.5])
+    y = np.sin(2 * np.pi * (x - theta[0]))
+    resid = y - y
+    J = np.ones((x.size, theta.size))
+
+    calls = {"n": 0}
+
+    def bad_refit(theta_init, locked_mask, bounds, x_in, y_in):
+        calls["n"] += 1
+        if calls["n"] <= 2:
+            return np.array(theta_init, float), True
+        raise RuntimeError("boom")
+
+    out = bootstrap_ci(
+        theta=theta,
+        residual=resid,
+        jacobian=J,
+        predict_full=lambda th: y,
+        x_all=x,
+        y_all=y,
+        fit_ctx={
+            "refit": bad_refit,
+            "bootstrap_jitter": 0.02,
+            "strict_refit": True,
+            "peaks": [object()],
+        },
+        n_boot=4,
+        seed=0,
+        workers=None,
+        alpha=0.1,
+        center_residuals=True,
+        return_band=False,
+    )
+    d = out.diagnostics
+    assert isinstance(d.get("refit_errors"), list)
+    assert any("boom" in str(s) for s in d.get("refit_errors"))
+    assert calls["n"] >= 2

--- a/tests/test_bootstrap_gui_jitter_applied.py
+++ b/tests/test_bootstrap_gui_jitter_applied.py
@@ -1,0 +1,43 @@
+import numpy as np
+
+from core.uncertainty import bootstrap_ci
+
+
+def test_gui_like_single_file_jitter_is_applied():
+    x = np.linspace(0, 1, 64)
+    theta = np.array([0.3, 1.0, 0.2, 0.5])
+    y = np.sin(2 * np.pi * (x - theta[0]))
+    resid = y - (y * 0 + y)
+    J = np.ones((x.size, theta.size))
+
+    calls = {"n": 0}
+
+    def accept_jitter_refit(theta_init, locked_mask, bounds, x_in, y_in):
+        calls["n"] += 1
+        return np.array(theta_init, float), True
+
+    out = bootstrap_ci(
+        theta=theta,
+        residual=resid,
+        jacobian=J,
+        predict_full=lambda th: y,
+        x_all=x,
+        y_all=y,
+        fit_ctx={
+            "refit": accept_jitter_refit,
+            "bootstrap_jitter": 0.05,
+            "strict_refit": True,
+            "peaks": [object()],
+        },
+        n_boot=16,
+        seed=123,
+        workers=None,
+        alpha=0.1,
+        center_residuals=True,
+        return_band=False,
+    )
+    d = out.diagnostics
+    assert d.get("bootstrap_mode") == "refit"
+    assert d.get("jitter_applied_any") is True
+    assert d.get("jitter_free_params", 0) >= 1
+    assert calls["n"] >= 1

--- a/tests/test_bootstrap_jitter_affects_init.py
+++ b/tests/test_bootstrap_jitter_affects_init.py
@@ -1,0 +1,49 @@
+import numpy as np
+
+from core.uncertainty import bootstrap_ci
+
+
+def _run_with_jitter(jitter):
+    x = np.linspace(0, 1, 32)
+    theta = np.array([0.2, 1.1, 0.3, 0.4])
+    y = np.cos(2 * np.pi * (x - theta[0]))
+    resid = y - y
+    J = np.ones((x.size, theta.size))
+
+    def accept(theta_init, locked_mask, bounds, x_in, y_in):
+        return np.array(theta_init, float), True
+
+    out = bootstrap_ci(
+        theta=theta,
+        residual=resid,
+        jacobian=J,
+        predict_full=lambda th: y,
+        x_all=x,
+        y_all=y,
+        fit_ctx={
+            "refit": accept,
+            "bootstrap_jitter": float(jitter),
+            "strict_refit": True,
+            "peaks": [object()],
+        },
+        n_boot=16,
+        seed=321,
+        workers=None,
+        alpha=0.1,
+        center_residuals=True,
+        return_band=False,
+    )
+    return out
+
+
+def test_jitter_changes_diagnostics_and_draws():
+    baseline = _run_with_jitter(0.0)
+    jittered = _run_with_jitter(0.1)
+
+    assert abs(baseline.diagnostics.get("jitter_last_rms", 0.0)) < 1e-12
+    assert jittered.diagnostics.get("jitter_last_rms", 0.0) > 0.0
+
+    keys = set(baseline.stats.keys()) & set(jittered.stats.keys())
+    assert keys
+    diffs = [abs(baseline.stats[k]["est"] - jittered.stats[k]["est"]) for k in keys]
+    assert any(d > 1e-8 for d in diffs)

--- a/tests/test_bootstrap_no_fallback_on_failure.py
+++ b/tests/test_bootstrap_no_fallback_on_failure.py
@@ -1,0 +1,38 @@
+import numpy as np
+import pytest
+
+from core.uncertainty import bootstrap_ci
+
+
+def test_bootstrap_raises_when_refits_fail():
+    x = np.linspace(0, 1, 32)
+    theta = np.array([0.4, 0.8, 0.25, 0.5])
+    y = np.sin(2 * np.pi * (x - theta[0]))
+    resid = y - y
+    J = np.ones((x.size, theta.size))
+
+    def always_fail(theta_init, locked_mask, bounds, x_in, y_in):
+        return np.array(theta_init, float), False
+
+    with pytest.raises(RuntimeError) as exc:
+        bootstrap_ci(
+            theta=theta,
+            residual=resid,
+            jacobian=J,
+            predict_full=lambda th: y,
+            x_all=x,
+            y_all=y,
+            fit_ctx={
+                "refit": always_fail,
+                "bootstrap_jitter": 0.05,
+                "strict_refit": True,
+                "peaks": [object()],
+            },
+            n_boot=8,
+            seed=123,
+            workers=None,
+            alpha=0.1,
+            center_residuals=True,
+            return_band=False,
+        )
+    assert "Insufficient successful" in str(exc.value)

--- a/tests/test_bootstrap_workers_and_determinism.py
+++ b/tests/test_bootstrap_workers_and_determinism.py
@@ -1,0 +1,60 @@
+import numpy as np
+
+from core.uncertainty import bootstrap_ci
+
+
+def _run(seed, jitter, workers):
+    x = np.linspace(0, 1, 128)
+    theta = np.array([0.25, 1.2, 0.3, 0.5])
+    y = np.cos(2 * np.pi * (x - theta[0]))
+    resid = y - y
+    J = np.ones((x.size, theta.size))
+
+    def accept_refit(theta_init, locked_mask, bounds, x_in, y_in):
+        return np.array(theta_init, float), True
+
+    out = bootstrap_ci(
+        theta=theta,
+        residual=resid,
+        jacobian=J,
+        predict_full=lambda th: y,
+        x_all=x,
+        y_all=y,
+        fit_ctx={
+            "refit": accept_refit,
+            "bootstrap_jitter": float(jitter),
+            "strict_refit": True,
+            "unc_workers": workers,
+            "peaks": [object()],
+        },
+        n_boot=32,
+        seed=seed,
+        workers=workers,
+        alpha=0.1,
+        center_residuals=True,
+        return_band=False,
+    )
+    return out
+
+
+def test_workers_and_determinism():
+    a = _run(seed=42, jitter=0.03, workers=4)
+    b = _run(seed=42, jitter=0.03, workers=2)
+    c = _run(seed=43, jitter=0.03, workers=4)
+    d = _run(seed=None, jitter=0.03, workers=4)
+
+    da, db = a.diagnostics, b.diagnostics
+    assert da.get("draw_workers_used") is not None
+    assert db.get("draw_workers_used") is not None
+
+    assert a.stats.keys() == b.stats.keys()
+    for k in a.stats:
+        for kk in ("est", "sd"):
+            assert abs(a.stats[k][kk] - b.stats[k][kk]) < 1e-12
+
+    changed = False
+    for k in a.stats:
+        if abs(a.stats[k]["est"] - c.stats[k]["est"]) > 1e-9:
+            changed = True
+            break
+    assert changed or (d.diagnostics.get("seed") is None)


### PR DESCRIPTION
## Summary
- ensure bootstrap raises when refits never succeed, apply jitter to free parameters, and expose jitter/worker diagnostics for inspection【F:core/uncertainty.py†L533-L538】【F:core/uncertainty.py†L791-L804】【F:core/uncertainty.py†L882-L1006】
- wire GUI bootstrap contexts to pass worker and jitter settings while updating the status line with the resolved values for visibility【F:ui/app.py†L3572-L3619】【F:ui/app.py†L3890-L3932】
- expand bootstrap tests to cover refit failure handling, jitter impact, and diagnostic error capture【F:tests/test_bootstrap_batch_refit_visible_errors.py†L6-L44】【F:tests/test_bootstrap_no_fallback_on_failure.py†L1-L38】【F:tests/test_bootstrap_jitter_affects_init.py†L1-L49】

## Testing
- `pytest -q tests/test_bootstrap_gui_jitter_applied.py tests/test_bootstrap_workers_and_determinism.py tests/test_bootstrap_batch_refit_visible_errors.py tests/test_bootstrap_no_fallback_on_failure.py tests/test_bootstrap_jitter_affects_init.py`


------
https://chatgpt.com/codex/tasks/task_e_68d8defbbcac8330ae4c3329a56cca7c