### PR TITLE
Add Bayesian diagnostic toggle

### DIFF
--- a/ui/app.py
+++ b/ui/app.py
@@ -994,6 +994,7 @@ class PeakFitApp:
         self.bayes_steps_var = tk.IntVar(value=int(self.cfg.get("bayes_steps", 4000)))
         self.bayes_thin_var = tk.IntVar(value=int(self.cfg.get("bayes_thin", 1)))
         self.bayes_prior_var = tk.StringVar(value=str(self.cfg.get("bayes_prior_sigma", "half_cauchy")))
+        self.bayes_diag_var = tk.BooleanVar(value=bool(self.cfg.get("bayes_diag", True)))
         self.seed_var = tk.StringVar(value="")
         self.gpu_chunk_var = tk.IntVar(value=262144)
 
@@ -1548,6 +1549,11 @@ class PeakFitApp:
         ttk.Label(bay, text="σ prior").grid(row=2, column=0, sticky="e")
         ttk.Combobox(bay, textvariable=self.bayes_prior_var, width=12,
                      values=("half_cauchy", "half_normal"), state="readonly").grid(row=2, column=1, sticky="w")
+        ttk.Checkbutton(
+            bay,
+            text="Compute diagnostics (ESS/R̂/MCSE)",
+            variable=self.bayes_diag_var,
+        ).grid(row=3, column=0, columnspan=2, sticky="w", padx=4, pady=(4, 0))
         r += 1
 
         # --- Bootstrap ties (visible + enabled only when Bootstrap + LMFIT refit solver) ---
@@ -3647,6 +3653,7 @@ class PeakFitApp:
                 "unc_workers": workers,
                 "unc_band_workers": workers,
                 "unc_use_gpu": bool(getattr(self, "use_gpu_var", None) and self.use_gpu_var.get()),
+                "bayes_diag": bool(self.bayes_diag_var.get()),
             }
             out = core_uncertainty.bayesian_ci(
                 theta_hat=theta,
@@ -3831,6 +3838,7 @@ class PeakFitApp:
             self._cfg_set("bayes_steps", steps)
             self._cfg_set("bayes_thin", thin)
             self._cfg_set("bayes_prior_sigma", str(self.bayes_prior_var.get()))
+            self._cfg_set("bayes_diag", bool(self.bayes_diag_var.get()))
             if method == "asymptotic":
                 res = self._run_asymptotic_uncertainty()
                 if abort_evt.is_set():
@@ -3960,6 +3968,7 @@ class PeakFitApp:
                     "unc_workers": workers,
                     "progress_cb": lambda msg: self.log_threadsafe(str(msg)),
                     "abort_event": abort_evt,
+                    "bayes_diag": bool(self.bayes_diag_var.get()),
                 }
                 # sensible bounds for MCMC to prevent runaway widths/etas
                 n_pk = len(self.peaks)
@@ -4100,21 +4109,22 @@ class PeakFitApp:
 
             self.status_info(f"Computed {label} uncertainty.")
             if isinstance(label, str) and label.startswith("Bayesian"):
-                try:
-                    out = res
-                    d = out.get("diagnostics", {}) if isinstance(out, dict) else getattr(out, "diagnostics", {}) or {}
-                    ess_min = d.get("ess_min"); rhat_max = d.get("rhat_max")
-                    mcse = d.get("mcse") or {}
-                    q16 = mcse.get("q16"); q50 = mcse.get("q50"); q84 = mcse.get("q84")
-                    self.log_threadsafe(
-                        f"Posterior health: ess_min={ess_min if ess_min is not None else 'nan'}, "
-                        f"rhat_max={rhat_max if rhat_max is not None else 'nan'}, "
-                        f"MCSE[q16/q50/q84]={q16 if q16 is not None else 'nan'}/"
-                        f"{q50 if q50 is not None else 'nan'}/"
-                        f"{q84 if q84 is not None else 'nan'}"
-                    )
-                except Exception:
-                    pass
+                if bool(self.bayes_diag_var.get()):
+                    try:
+                        out = res
+                        d = out.get("diagnostics", {}) if isinstance(out, dict) else getattr(out, "diagnostics", {}) or {}
+                        ess_min = d.get("ess_min"); rhat_max = d.get("rhat_max")
+                        mcse = d.get("mcse") or {}
+                        q16 = mcse.get("q16"); q50 = mcse.get("q50"); q84 = mcse.get("q84")
+                        self.log_threadsafe(
+                            f"Posterior health: ess_min={ess_min if ess_min is not None else 'nan'}, "
+                            f"rhat_max={rhat_max if rhat_max is not None else 'nan'}, "
+                            f"MCSE[q16/q50/q84]={q16 if q16 is not None else 'nan'}/"
+                            f"{q50 if q50 is not None else 'nan'}/"
+                            f"{q84 if q84 is not None else 'nan'}"
+                        )
+                    except Exception:
+                        pass
             # --- cache signature for export parity ---
             try:
                 theta_sig = []

--- a/ui/helptext.py
+++ b/ui/helptext.py
@@ -156,7 +156,11 @@ def build_help(opts: dict) -> str:
         ---------------------------
         • Asymptotic (default band ON): fast covariance-based CIs using JᵀJ; prediction band via delta method; lightly smoothed.
         • Bootstrap: residual resampling → refit → parameter distributions; seeded for reproducibility; respects locks/bounds.
-        • Bayesian (emcee): posterior mean/SD and 95% credible intervals; ESS/R-hat diagnostics; band from posterior predictive.
+        • Bayesian (emcee): posterior mean/SD and 95% credible intervals; optional diagnostics (ESS, R̂, MCSE) and posterior-predictive band.
+          – ESS (effective sample size): higher is better; <200 suggests more steps/chains.
+          – R̂ (“R-hat”): should be ≈1.00; >1.05 suggests non-convergence.
+          – MCSE: Monte Carlo standard error of reported quantiles (q16/q50/q84); smaller is better.
+          You can toggle diagnostics via “Compute diagnostics (ESS/R̂/MCSE)” to reduce overhead on large runs.
           (If emcee is not installed, the app reports “NotAvailable”.)
 
         Batch processing


### PR DESCRIPTION
## Summary
- add a `bayes_diag` switch to `bayesian_ci` so heavy ESS/R̂/MCSE diagnostics only run when requested and the diagnostics payload reflects the toggle
- expose a persisted "Compute diagnostics" checkbox in the GUI, pass the flag through synchronous/worker Bayesian runs, and suppress the posterior log when disabled
- plumb the batch configuration flag into routed Bayesian jobs and document the optional diagnostics/toggle in Help

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9627aa4708330a30ce0a2fa2e14b7