### PR TITLE
Improve bootstrap refit robustness and diagnostics

### DIFF
--- a/batch/runner.py
+++ b/batch/runner.py
@@ -515,7 +515,9 @@ def run_batch(
                             mode=res.get("mode", "add"),
                             fit_mask=fit_mask,
                         )
-                    return np.asarray(out.get("theta", theta_init), float), True
+                    theta_out = np.asarray(out.get("theta", theta_init), float)
+                    ok = bool(out.get("fit_ok", out.get("ok", True))) and np.all(np.isfinite(theta_out))
+                    return theta_out, ok
 
                 fit_ctx.update({"refit": _refit_wrapper})
 

--- a/batch/runner.py
+++ b/batch/runner.py
@@ -506,17 +506,29 @@ def run_batch(
                             bounds=bounds,
                         )
                     except TypeError:
-                        out = _fit_api.run_fit_consistent(
-                            x,
-                            y,
-                            peaks_start,
-                            cfg,
-                            baseline=res.get("baseline"),
-                            mode=res.get("mode", "add"),
-                            fit_mask=fit_mask,
-                        )
-                    theta_out = np.asarray(out.get("theta", theta_init), float)
-                    ok = bool(out.get("fit_ok", out.get("ok", True))) and np.all(np.isfinite(theta_out))
+                        # Retry without optional kwargs or fit_mask for older signatures
+                        try:
+                            out = _fit_api.run_fit_consistent(
+                                x,
+                                y,
+                                peaks_start,
+                                cfg,
+                                baseline=res.get("baseline"),
+                                mode=res.get("mode", "add"),
+                            )
+                        except TypeError:
+                            # Final minimal fallback for very old signatures
+                            out = _fit_api.run_fit_consistent(x, y, peaks_start, cfg)
+
+                    # Normalize fitter output: accept dict or array-like
+                    if isinstance(out, dict):
+                        theta_out = np.asarray(out.get("theta", theta_init), float)
+                        ok_flag = out.get("fit_ok", out.get("ok", True))
+                    else:
+                        theta_out = np.asarray(out, float)
+                        ok_flag = True  # no flags provided; rely on finite check below
+
+                    ok = bool(ok_flag) and np.all(np.isfinite(theta_out))
                     return theta_out, ok
 
                 fit_ctx.update({"refit": _refit_wrapper})

--- a/core/uncertainty.py
+++ b/core/uncertainty.py
@@ -596,6 +596,9 @@ def bootstrap_ci(
         y_arr = y_arr[:n]
     y_all = y_arr if y_arr.size == n else None
 
+    # Canonical starting point for jitter (allow caller override via theta0)
+    theta0 = np.asarray(fit.get("theta0", theta), float)
+
     # Center residuals if requested
     r = residual - residual.mean() if center_residuals else residual.copy()
 
@@ -622,6 +625,37 @@ def bootstrap_ci(
 
     # If we have no peaks, fall back to asymptotic CI to avoid crashy path
     if not peaks_obj:
+        def _peaks_from_theta(th_like: np.ndarray):
+            try:
+                from . import peaks as _peaks_mod
+            except Exception:
+                return []
+
+            arr = np.asarray(th_like, float).ravel()
+            if arr.size % 4 != 0 or arr.size == 0:
+                return []
+
+            out: list[_peaks_mod.Peak] = []
+            for i in range(arr.size // 4):
+                j = 4 * i
+                try:
+                    out.append(
+                        _peaks_mod.Peak(
+                            center=float(arr[j + 0]),
+                            height=float(arr[j + 1]),
+                            fwhm=float(arr[j + 2]),
+                            eta=float(arr[j + 3]),
+                        )
+                    )
+                except Exception:
+                    return []
+            return out
+
+        peaks_obj = _peaks_from_theta(theta0)
+
+    user_refit = fit.get("refit", None)
+
+    if not peaks_obj and not callable(user_refit):
         ymodel = predict_full if callable(predict_full) else (lambda _th: np.asarray(y_all, float))
         res_asym = asymptotic_ci(theta, residual, J, ymodel, alpha=alpha)
 
@@ -779,10 +813,35 @@ def bootstrap_ci(
         return th, ok
 
     # --- Optional user-supplied refit from fit_ctx (batch path) ---
-    user_refit = fit.get("refit", None)
     if callable(user_refit):
+        from inspect import signature as _inspect_signature
+
+        try:
+            _user_sig = _inspect_signature(user_refit)
+        except Exception:
+            _user_sig = None
+
         def refit(theta_init, x, y):
-            out = user_refit(theta_init, locked_mask, bounds, x, y)
+            if _user_sig is not None:
+                for args in (
+                    (theta_init, locked_mask, bounds, x, y),
+                    (theta_init, x, y),
+                ):
+                    try:
+                        _user_sig.bind_partial(*args)
+                    except TypeError:
+                        continue
+                    out_local = user_refit(*args)
+                    break
+                else:
+                    out_local = user_refit(theta_init, locked_mask, bounds, x, y)
+            else:
+                try:
+                    out_local = user_refit(theta_init, locked_mask, bounds, x, y)
+                except TypeError:
+                    out_local = user_refit(theta_init, x, y)
+
+            out = out_local
             if isinstance(out, tuple) and len(out) == 2:
                 th_new, ok = out
                 th_new = np.asarray(th_new, float)
@@ -805,7 +864,6 @@ def bootstrap_ci(
         return None
 
     # Free-parameter mask for optional linear fallback
-    theta0 = np.asarray(fit.get("theta0", theta), float)
     P = theta.size
 
     locked_arr = _canon_locked_mask(locked_mask, P)

--- a/core/uncertainty.py
+++ b/core/uncertainty.py
@@ -809,7 +809,7 @@ def bootstrap_ci(
             bounds=bounds, baseline=baseline
         )
         th = np.asarray(res.get("theta", theta_arr), float)
-        ok = True
+        ok = np.all(np.isfinite(th))
         return th, ok
 
     # --- Optional user-supplied refit from fit_ctx (batch path) ---

--- a/core/uncertainty.py
+++ b/core/uncertainty.py
@@ -962,7 +962,17 @@ def bootstrap_ci(
                             break
                     except Exception:
                         pass
-                _, th_new, ok, err_msg, jit_info = f.result()
+                try:
+                    _, th_new, ok, err_msg, jit_info = f.result()
+                except Exception as e:
+                    # Count as failed draw; capture first few error messages
+                    n_fail += 1
+                    if len(refit_errors) < 5:
+                        refit_errors.append(f"{type(e).__name__}: {e}")
+                    done_cnt += 1
+                    _pulse(done_cnt)
+                    continue
+
                 jitter_applied_last, jitter_reason_last, jitter_rms_last = jit_info
                 done_cnt += 1
                 _pulse(done_cnt)

--- a/tests/test_bayes_diag_toggle_gates_metrics.py
+++ b/tests/test_bayes_diag_toggle_gates_metrics.py
@@ -1,0 +1,63 @@
+import numpy as np
+import pytest
+
+emcee = pytest.importorskip("emcee")
+from core.uncertainty import bayesian_ci
+
+
+def _toy_model(th, n=16):
+    # 1D param + log-sigma inferred internally; produce zero residual signal
+    return np.zeros(n, dtype=float)
+
+
+def _residual_fn(th, n=16):
+    return np.zeros(n, dtype=float)
+
+
+def test_bayes_diag_disabled_skips_metrics(monkeypatch):
+    # Raise if diagnostics are attempted
+    monkeypatch.setattr("core.mcmc_utils.ess_autocorr", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("ESS called")))
+    monkeypatch.setattr("core.mcmc_utils.rhat_split", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("Rhat called")))
+
+    theta = np.array([0.5])  # single param; sigma handled internally
+    res = bayesian_ci(
+        theta_hat=theta,
+        model=_toy_model,
+        predict_full=_toy_model,
+        x_all=np.arange(16, dtype=float),
+        y_all=np.zeros(16),
+        residual_fn=_residual_fn,
+        fit_ctx={"bayes_diag": False, "alpha": 0.05},
+        n_walkers=16, n_burn=10, n_steps=40, thin=2,
+        seed=123, workers=0, return_band=False,
+    )
+    d = res.diagnostics or {}
+    assert d.get("diagnostics_enabled") is False
+    assert d.get("ess_min") is None
+    assert d.get("rhat_max") is None
+    assert d.get("mcse") is None
+
+
+def test_bayes_diag_enabled_populates_metrics(monkeypatch):
+    # Provide harmless, fast stubs
+    monkeypatch.setattr("core.mcmc_utils.ess_autocorr", lambda post: np.ones((1,1,2)))
+    monkeypatch.setattr("core.mcmc_utils.rhat_split", lambda post: np.ones((1,1,2)))
+
+    theta = np.array([0.5])
+    res = bayesian_ci(
+        theta_hat=theta,
+        model=_toy_model,
+        predict_full=_toy_model,
+        x_all=np.arange(16, dtype=float),
+        y_all=np.zeros(16),
+        residual_fn=_residual_fn,
+        fit_ctx={"bayes_diag": True, "alpha": 0.05},
+        n_walkers=16, n_burn=10, n_steps=40, thin=2,
+        seed=123, workers=0, return_band=False,
+    )
+    d = res.diagnostics or {}
+    assert d.get("diagnostics_enabled") is True
+    assert d.get("ess_min") is not None
+    assert d.get("rhat_max") is not None
+    # mcse dict present
+    assert isinstance(d.get("mcse"), dict)

--- a/tests/test_bootstrap_core_refit_typeerror_fallback.py
+++ b/tests/test_bootstrap_core_refit_typeerror_fallback.py
@@ -1,0 +1,63 @@
+import numpy as np
+
+from core import uncertainty as U
+
+
+def test_core_refit_signature_fallback_and_peaks_injection(monkeypatch):
+    n = 10
+    theta0 = np.array([10.0, 1.0, 2.0, 0.1])
+    residual = np.zeros(n)
+    J = np.ones((n, theta0.size))
+    x = np.arange(n, dtype=float)
+    y = np.zeros(n)
+
+    seen = {"called_without_theta": 0, "called_with_theta": 0, "first_center": None}
+
+    # Simulate a fitter that FAILS if theta_init not provided,
+    # and SUCCEEDS (and echoes theta_init) when it is provided.
+    def fake_run_fit_consistent(*, x=None, y=None, peaks_in=None, cfg=None,
+                                baseline=None, mode=None, fit_mask=None, **kw):
+        if "theta_init" not in kw:
+            # Force fallback to the "with theta_init" variant
+            seen["called_without_theta"] += 1
+            raise RuntimeError("need theta_init")
+        seen["called_with_theta"] += 1
+        th = np.asarray(kw["theta_init"], float).copy()
+        # Capture p0 peaks mapping — first peak center must match jittered theta[0]
+        if peaks_in and len(peaks_in) >= 1:
+            seen["first_center"] = float(peaks_in[0].center)
+        return {"theta": th, "fit_ok": True}
+
+    monkeypatch.setattr("core.fit_api.run_fit_consistent", fake_run_fit_consistent)
+
+    # Tiny jitter forces θ→peaks mapping path
+    fit_ctx = dict(
+        x_all=x, y_all=y,
+        residual_fn=lambda th: np.zeros_like(x),
+        predict_full=lambda th: np.zeros_like(x),
+        strict_refit=True,
+        bootstrap_jitter=0.10,   # jitter applied on free params
+        lmfit_share_fwhm=False,
+        lmfit_share_eta=False,
+    )
+
+    res = U.bootstrap_ci(
+        theta=theta0,
+        residual=residual,
+        jacobian=J,
+        predict_full=lambda th: np.zeros_like(x),
+        x_all=x,
+        y_all=y,
+        fit_ctx=fit_ctx,
+        n_boot=2, seed=42, workers=None, alpha=0.05,
+        center_residuals=True, return_band=False,
+    )
+
+    d = res.diagnostics or {}
+    assert d.get("n_success", 0) >= 1
+    # Fallback was exercised at least once
+    assert seen["called_without_theta"] >= 1
+    assert seen["called_with_theta"] >= 1
+    # Peaks injection should mirror jittered theta[0] (not the original theta0[0])
+    assert seen["first_center"] is not None
+    assert not np.isclose(seen["first_center"], theta0[0])

--- a/tests/test_bootstrap_jitter_changes_theta_init.py
+++ b/tests/test_bootstrap_jitter_changes_theta_init.py
@@ -1,0 +1,53 @@
+import numpy as np
+
+from core.uncertainty import bootstrap_ci
+
+
+def test_jitter_changes_theta_init_on_free_params():
+    n = 12
+    theta = np.array([5.0, 2.0, 1.0, 0.5])
+    residual = np.zeros(n)
+    J = np.ones((n, theta.size))
+    x = np.arange(n, dtype=float)
+    y = np.zeros(n)
+
+    captured = []
+
+    def capturing_refit(theta_init, x_in, y_in):
+        captured.append(np.asarray(theta_init, float).copy())
+        # echo back θ so we count success
+        return (np.asarray(theta_init, float), True)
+
+    # With jitter=0 the starts are identical
+    fit_ctx_zero = dict(
+        x_all=x, y_all=y,
+        residual_fn=lambda th: np.zeros_like(x),
+        predict_full=lambda th: np.zeros_like(x),
+        strict_refit=True,
+        refit=capturing_refit,
+    )
+    captured.clear()
+    bootstrap_ci(theta, residual, J, predict_full=lambda th: np.zeros_like(x),
+                 x_all=x, y_all=y, fit_ctx=fit_ctx_zero,
+                 n_boot=3, seed=123, workers=None,
+                 alpha=0.05, center_residuals=True, return_band=False)
+    # All captured starts equal to theta
+    assert all(np.allclose(t, theta) for t in captured)
+
+    # With jitter > 0, at least some starts should differ on free params
+    fit_ctx_jit = dict(fit_ctx_zero)
+    captured.clear()
+    bootstrap_ci(theta, residual, J, predict_full=lambda th: np.zeros_like(x),
+                 x_all=x, y_all=y, fit_ctx=fit_ctx_jit,
+                 n_boot=6, seed=123, workers=None,
+                 alpha=0.05, center_residuals=True, return_band=False,
+                 )
+    # Default jitter in engine is 0 unless provided; emulate GUI by setting it:
+    # Re-run with explicit jitter
+    captured.clear()
+    bootstrap_ci(theta, residual, J, predict_full=lambda th: np.zeros_like(x),
+                 x_all=x, y_all=y,
+                 fit_ctx=fit_ctx_jit | {"bootstrap_jitter": 0.25},
+                 n_boot=6, seed=123, workers=None,
+                 alpha=0.05, center_residuals=True, return_band=False)
+    assert any(not np.allclose(t, theta) for t in captured)

--- a/tests/test_bootstrap_refit_nan_not_counted.py
+++ b/tests/test_bootstrap_refit_nan_not_counted.py
@@ -1,0 +1,42 @@
+import numpy as np
+import pytest
+
+from core.uncertainty import bootstrap_ci
+
+
+def test_nan_refits_are_not_counted(monkeypatch):
+    # Minimal, deterministic inputs
+    n = 8
+    theta = np.array([1.0, 2.0, 3.0, 0.5])
+    residual = np.zeros(n)
+    J = np.ones((n, theta.size))
+
+    # Refits return NaNs but claim success -> should be treated as failure
+    def bad_refit(theta_init, x, y):
+        return (np.full_like(theta_init, np.nan), True)
+
+    fit_ctx = {
+        "x_all": np.arange(n, dtype=float),
+        "y_all": np.zeros(n),
+        "residual_fn": lambda th: np.zeros(n),
+        "predict_full": lambda th: np.zeros(n),
+        "strict_refit": True,
+        "refit": bad_refit,
+    }
+
+    with pytest.raises(RuntimeError, match="Insufficient successful bootstrap refits"):
+        bootstrap_ci(
+            theta=theta,
+            residual=residual,
+            jacobian=J,
+            predict_full=lambda th: np.zeros(n),
+            x_all=np.arange(n, dtype=float),
+            y_all=np.zeros(n),
+            fit_ctx=fit_ctx,
+            n_boot=3,
+            seed=123,
+            workers=None,
+            alpha=0.05,
+            center_residuals=True,
+            return_band=False,
+        )

--- a/tests/test_core_refit_passes_fit_mask.py
+++ b/tests/test_core_refit_passes_fit_mask.py
@@ -1,0 +1,37 @@
+import numpy as np
+
+from core import uncertainty as U
+
+
+def test_fit_mask_kwarg_is_propagated(monkeypatch):
+    n = 9
+    theta = np.array([1.0, 2.0, 3.0, 0.2])
+    residual = np.zeros(n)
+    J = np.ones((n, theta.size))
+    x = np.arange(n, dtype=float)
+    y = np.zeros(n)
+
+    observed = {"fit_mask_seen": False, "mask_seen": False}
+
+    # Signature includes fit_mask; fail if not provided.
+    def fake_run_fit_consistent(*, x=None, y=None, peaks_in=None, cfg=None,
+                                baseline=None, mode=None, fit_mask=None, **kw):
+        observed["fit_mask_seen"] = fit_mask is not None and fit_mask.shape == x.shape
+        observed["mask_seen"] = ("mask" in kw)
+        return {"theta": np.asarray(theta, float), "fit_ok": True}
+
+    monkeypatch.setattr("core.fit_api.run_fit_consistent", fake_run_fit_consistent)
+
+    res = U.bootstrap_ci(
+        theta=theta,
+        residual=residual,
+        jacobian=J,
+        predict_full=lambda th: np.zeros_like(x),
+        x_all=x,
+        y_all=y,
+        fit_ctx={"x": x, "y": y, "strict_refit": True},
+        n_boot=2, seed=1, workers=None, alpha=0.05, center_residuals=True, return_band=False,
+    )
+    assert res is not None
+    assert observed["fit_mask_seen"] is True
+    assert observed["mask_seen"] is False  # legacy kw must NOT be used


### PR DESCRIPTION
## Summary
- synthesize peaks from theta when refit lacks peaks and support user refit signature fallbacks
- ensure refits returning NaNs are treated as failures while preserving jitter and fit mask handling
- add regression tests for bootstrap refit flows and Bayesian diagnostic toggles

## Testing
- pytest tests/test_bootstrap_refit_nan_not_counted.py tests/test_bootstrap_core_refit_typeerror_fallback.py tests/test_bootstrap_jitter_changes_theta_init.py tests/test_core_refit_passes_fit_mask.py tests/test_bayes_diag_toggle_gates_metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68d96f50b24483309e20ccbb12c996e7