### PR TITLE
Align Bayesian quantile keys with bootstrap outputs

### DIFF
--- a/tests/test_bayes_band_gating.py
+++ b/tests/test_bayes_band_gating.py
@@ -1,0 +1,87 @@
+import numpy as np
+import pytest
+
+from core.uncertainty import bayesian_ci
+
+
+def _dummy_predict(x):
+    def f(th):
+        return th[0] * x + th[1]
+    return f
+
+
+@pytest.mark.skipif(pytest.importorskip("emcee", reason=None) is None, reason="emcee required")
+def test_bayes_band_gating():
+    x = np.linspace(0.0, 1.0, 64)
+    y = np.zeros_like(x)
+    theta = np.array([0.1, 1.0, 0.5, 0.25], float)
+
+    out_ok = bayesian_ci(
+        theta_hat=theta,
+        predict_full=_dummy_predict(x),
+        x_all=x,
+        y_all=y,
+        residual_fn=lambda th: y - _dummy_predict(x)(th),
+        n_walkers=12,
+        n_burn=50,
+        n_steps=60,
+        thin=1,
+        fit_ctx={
+            "bayes_diagnostics": True,
+            "bayes_band_enabled": True,
+            "bayes_diag_ess_min": 0.0,
+            "bayes_diag_rhat_max": 10.0,
+            "bayes_diag_mcse_mean": float("inf"),
+        },
+        return_band=True,
+        seed=123,
+    )
+    assert out_ok.band is not None
+
+    out_fail = bayesian_ci(
+        theta_hat=theta,
+        predict_full=_dummy_predict(x),
+        x_all=x,
+        y_all=y,
+        residual_fn=lambda th: y - _dummy_predict(x)(th),
+        n_walkers=12,
+        n_burn=50,
+        n_steps=60,
+        thin=1,
+        fit_ctx={
+            "bayes_diagnostics": True,
+            "bayes_band_enabled": True,
+            "bayes_diag_ess_min": 1e6,
+            "bayes_diag_rhat_max": 1.0,
+            "bayes_diag_mcse_mean": 0.0,
+        },
+        return_band=True,
+        seed=123,
+    )
+    assert out_fail.band is None
+    assert bool(out_fail.diagnostics.get("band_gated"))
+
+    out_forced = bayesian_ci(
+        theta_hat=theta,
+        predict_full=_dummy_predict(x),
+        x_all=x,
+        y_all=y,
+        residual_fn=lambda th: y - _dummy_predict(x)(th),
+        n_walkers=12,
+        n_burn=50,
+        n_steps=60,
+        thin=1,
+        fit_ctx={
+            "bayes_diagnostics": True,
+            "bayes_band_enabled": True,
+            "bayes_band_force": True,
+            "bayes_diag_ess_min": 1e6,
+            "bayes_diag_rhat_max": 1.0,
+            "bayes_diag_mcse_mean": 0.0,
+        },
+        return_band=True,
+        seed=123,
+    )
+    assert out_forced.band is not None
+    assert not bool(out_forced.diagnostics.get("band_gated"))
+    assert bool(out_forced.diagnostics.get("band_forced"))

--- a/tests/test_bayes_band_subset_deterministic.py
+++ b/tests/test_bayes_band_subset_deterministic.py
@@ -1,0 +1,44 @@
+import numpy as np
+import pytest
+
+from core.uncertainty import bayesian_ci
+
+
+@pytest.mark.skipif(pytest.importorskip("emcee", reason=None) is None, reason="emcee required")
+def test_bayes_band_subset_deterministic():
+    x = np.linspace(0.0, 1.0, 32)
+    y = np.zeros_like(x)
+    theta = np.array([0.2, 1.0, 0.5, 0.5], float)
+
+    kwargs = dict(
+        theta_hat=theta,
+        predict_full=lambda th: th[0] * x + th[1],
+        x_all=x,
+        y_all=y,
+        residual_fn=lambda th: y - (th[0] * x + th[1]),
+        n_walkers=12,
+        n_burn=40,
+        n_steps=50,
+        thin=1,
+        fit_ctx={
+            "bayes_diagnostics": True,
+            "bayes_band_enabled": True,
+            "bayes_band_max_draws": 16,
+            "bayes_diag_ess_min": 0.0,
+            "bayes_diag_rhat_max": 10.0,
+            "bayes_diag_mcse_mean": float("inf"),
+        },
+        return_band=True,
+        seed=777,
+    )
+
+    res1 = bayesian_ci(**kwargs)
+    res2 = bayesian_ci(**kwargs)
+
+    assert res1.band is not None and res2.band is not None
+    xb1, lo1, hi1 = res1.band
+    xb2, lo2, hi2 = res2.band
+
+    np.testing.assert_allclose(xb1, xb2)
+    np.testing.assert_allclose(lo1, lo2)
+    np.testing.assert_allclose(hi1, hi2)

--- a/tests/test_bayes_band_threshold_gating.py
+++ b/tests/test_bayes_band_threshold_gating.py
@@ -1,0 +1,104 @@
+import numpy as np
+import pytest
+
+from core.uncertainty import bayesian_ci
+
+
+pytestmark = pytest.mark.filterwarnings("ignore::RuntimeWarning")
+
+
+def _fixture(n=64, sigma=0.03, seed=0):
+    rng = np.random.default_rng(seed)
+    x = np.linspace(0.0, 1.0, n)
+    a_true, b_true = 1.2, 0.7
+    y = a_true + b_true * x + rng.normal(scale=sigma, size=n)
+    X = np.column_stack([np.ones_like(x), x])
+    th_hat, *_ = np.linalg.lstsq(X, y, rcond=None)
+    th_hat = np.asarray(th_hat, float)
+
+    def model(theta):
+        theta = np.asarray(theta, float)
+        return theta[0] + theta[1] * x
+
+    return x, y, th_hat, model
+
+
+@pytest.mark.skipif(pytest.importorskip("emcee") is None, reason="emcee not available")
+def test_bayes_band_gates_when_diagnostics_unhealthy():
+    x, y, theta_hat, model = _fixture()
+
+    fit_ctx = {
+        "alpha": 0.1,
+        "bayes_diagnostics": True,
+        "bayes_band_enabled": True,
+        "bayes_band_force": False,
+        "bayes_band_max_draws": 64,
+        # Intentionally impossible thresholds to force gating:
+        "bayes_diag_ess_min": 1e9,
+        "bayes_diag_rhat_max": 1e-6,
+        "bayes_diag_mcse_mean": 0.0,
+        "unc_band_workers": 0,
+    }
+    res = bayesian_ci(
+        theta_hat=theta_hat,
+        model=model,
+        predict_full=model,
+        x_all=x,
+        y_all=y,
+        residual_fn=lambda th: y - model(th),
+        fit_ctx=fit_ctx,
+        n_walkers=16,
+        n_burn=100,
+        n_steps=160,
+        thin=2,
+        seed=42,
+        workers=None,
+        return_band=True,
+    )
+
+    d = res.diagnostics or {}
+    assert d.get("diagnostics_enabled") is True
+    assert d.get("band_gated") is True
+    # Threshold gating should report this reason:
+    assert d.get("band_skip_reason") == "diagnostics_unhealthy"
+    assert res.band is None
+
+
+@pytest.mark.skipif(pytest.importorskip("emcee") is None, reason="emcee not available")
+def test_bayes_band_forces_even_if_unhealthy():
+    x, y, theta_hat, model = _fixture()
+
+    fit_ctx = {
+        "alpha": 0.1,
+        "bayes_diagnostics": True,
+        "bayes_band_enabled": True,
+        "bayes_band_force": True,   # force it this time
+        "bayes_band_max_draws": 64,
+        "bayes_diag_ess_min": 1e9,  # still impossible, but should be ignored
+        "bayes_diag_rhat_max": 1e-6,
+        "bayes_diag_mcse_mean": 0.0,
+        "unc_band_workers": 0,
+    }
+    res = bayesian_ci(
+        theta_hat=theta_hat,
+        model=model,
+        predict_full=model,
+        x_all=x,
+        y_all=y,
+        residual_fn=lambda th: y - model(th),
+        fit_ctx=fit_ctx,
+        n_walkers=16,
+        n_burn=80,
+        n_steps=160,
+        thin=2,
+        seed=43,
+        workers=None,
+        return_band=True,
+    )
+
+    d = res.diagnostics or {}
+    assert d.get("band_forced") is True
+    assert d.get("band_gated") is False
+    assert d.get("band_source") == "posterior_predictive_subset"
+    assert d.get("band_draws_used", 0) > 0
+    assert res.band is not None

--- a/tests/test_bayes_seed_determinism.py
+++ b/tests/test_bayes_seed_determinism.py
@@ -1,0 +1,97 @@
+import numpy as np
+import pytest
+
+from core.uncertainty import bayesian_ci
+
+
+def _fixture(n=64, sigma=0.03, seed=0):
+    rng = np.random.default_rng(seed)
+    x = np.linspace(0.0, 1.0, n)
+    a_true, b_true = 1.3, 0.4
+    y = a_true + b_true * x + rng.normal(scale=sigma, size=n)
+    X = np.column_stack([np.ones_like(x), x])
+    th_hat, *_ = np.linalg.lstsq(X, y, rcond=None)
+    th_hat = np.asarray(th_hat, float)
+
+    def model(theta):
+        theta = np.asarray(theta, float)
+        return theta[0] + theta[1] * x
+
+    return x, y, th_hat, model
+
+
+def _extract_stat_vector(stats: dict, name: str):
+    blk = stats[name]
+    return np.array(
+        [blk["est"], blk["sd"], blk["p2.5"], blk["p97.5"]],
+        dtype=float,
+    )
+
+
+@pytest.mark.skipif(pytest.importorskip("emcee") is None, reason="emcee not available")
+def test_bayesian_seed_is_deterministic():
+    x, y, theta_hat, model = _fixture()
+
+    common_kwargs = dict(
+        theta_hat=theta_hat,
+        model=model,
+        predict_full=model,
+        x_all=x,
+        y_all=y,
+        residual_fn=lambda th: y - model(th),
+        fit_ctx={"alpha": 0.1, "bayes_diagnostics": False},
+        n_walkers=16,
+        n_burn=80,
+        n_steps=160,
+        thin=2,
+        workers=None,
+        return_band=False,
+        param_names=["a", "b"],
+    )
+
+    r1 = bayesian_ci(seed=123, **common_kwargs)
+    r2 = bayesian_ci(seed=123, **common_kwargs)
+
+    v1_a = _extract_stat_vector(r1.stats, "a")
+    v2_a = _extract_stat_vector(r2.stats, "a")
+    v1_b = _extract_stat_vector(r1.stats, "b")
+    v2_b = _extract_stat_vector(r2.stats, "b")
+
+    np.testing.assert_allclose(v1_a, v2_a, rtol=0, atol=0)
+    np.testing.assert_allclose(v1_b, v2_b, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(pytest.importorskip("emcee") is None, reason="emcee not available")
+def test_bayesian_different_seeds_change_output_somewhat():
+    x, y, theta_hat, model = _fixture()
+
+    common_kwargs = dict(
+        theta_hat=theta_hat,
+        model=model,
+        predict_full=model,
+        x_all=x,
+        y_all=y,
+        residual_fn=lambda th: y - model(th),
+        fit_ctx={"alpha": 0.1, "bayes_diagnostics": False},
+        n_walkers=16,
+        n_burn=80,
+        n_steps=160,
+        thin=2,
+        workers=None,
+        return_band=False,
+        param_names=["a", "b"],
+    )
+
+    r1 = bayesian_ci(seed=777, **common_kwargs)
+    r2 = bayesian_ci(seed=778, **common_kwargs)
+
+    # it's possible medians match to high precision by chance; compare full vectors
+    v1 = np.concatenate([
+        _extract_stat_vector(r1.stats, "a"),
+        _extract_stat_vector(r1.stats, "b"),
+    ])
+    v2 = np.concatenate([
+        _extract_stat_vector(r2.stats, "a"),
+        _extract_stat_vector(r2.stats, "b"),
+    ])
+    assert np.any(np.abs(v1 - v2) > 1e-8), "Different seeds should change posterior summaries at least slightly"

--- a/tests/test_perf_seed_drives_uncertainty.py
+++ b/tests/test_perf_seed_drives_uncertainty.py
@@ -1,0 +1,238 @@
+import numpy as np
+import pytest
+
+from core import uncertainty as U
+
+
+def _fake_predict(th, x):
+    return np.zeros_like(x)
+
+
+def _fake_resid(th, x):
+    return np.zeros_like(x)
+
+
+class _DummySamplerBand:
+    def __init__(self, nwalkers, dim, log_prob_fn, pool=None):
+        self._log_prob = log_prob_fn
+        self.pool = pool
+        self.nwalkers = nwalkers
+        self.dim = dim
+        self.acceptance_fraction = np.full(nwalkers, 0.3)
+        rng = np.random.RandomState(1234)
+        self._chain = rng.normal(size=(128, nwalkers, dim))
+
+    def run_mcmc(self, state, step, progress=False, skip_initial_state_check=True):
+        return state, None, None
+
+    def get_chain(self, discard=0, thin=1, flat=False):
+        arr = self._chain
+        if discard:
+            arr = arr[discard:]
+        if thin and thin > 1:
+            arr = arr[::thin]
+        return arr if not flat else arr.reshape(-1, arr.shape[-1])
+
+
+def test_bootstrap_uses_global_seed(monkeypatch):
+    x = np.linspace(0, 1, 64)
+    y = np.zeros_like(x)
+    theta = np.array([1.0, 2.0, 3.0, 0.5])
+
+    def refit(theta_init, x, y, **kw):
+        return {"theta": np.asarray(theta_init, float), "fit_ok": True}
+
+    monkeypatch.setattr(U, "refit", refit, raising=False)
+
+    out1 = U.bootstrap_ci(
+        theta=theta,
+        residual=y,
+        jacobian=np.zeros((x.size, theta.size)),
+        predict_full=lambda th: _fake_predict(th, x),
+        x_all=x,
+        y_all=y,
+        seed=123,
+        n_boot=8,
+        fit_ctx={},
+        workers=None,
+        return_band=False,
+    )
+    out2 = U.bootstrap_ci(
+        theta=theta,
+        residual=y,
+        jacobian=np.zeros((x.size, theta.size)),
+        predict_full=lambda th: _fake_predict(th, x),
+        x_all=x,
+        y_all=y,
+        seed=123,
+        n_boot=8,
+        fit_ctx={},
+        workers=None,
+        return_band=False,
+    )
+    assert out1.stats == out2.stats
+
+
+def test_bayesian_respects_seed(monkeypatch):
+    emcee = pytest.importorskip("emcee")
+
+    class DummySampler:
+        def __init__(self, *a, **k):
+            self.acceptance_fraction = np.array([0.25, 0.25])
+
+        def run_mcmc(self, state, step, **kw):
+            return state, None, None
+
+        def get_chain(self, discard=0, thin=1, flat=False):
+            rng = np.random.RandomState(1234)
+            arr = rng.randn(40, 2, 3)
+            if discard:
+                arr = arr[discard:]
+            if thin and thin > 1:
+                arr = arr[::thin]
+            return arr if not flat else arr.reshape(-1, 3)
+
+    monkeypatch.setattr(emcee, "EnsembleSampler", DummySampler)
+
+    x = np.linspace(0, 1, 32)
+    y = np.zeros_like(x)
+    theta = np.array([0.1, 1.0, 0.5, 0.4])
+
+    r1 = U.bayesian_ci(
+        theta_hat=theta,
+        model=lambda th: _fake_predict(th, x),
+        predict_full=lambda th: _fake_predict(th, x),
+        x_all=x,
+        y_all=y,
+        residual_fn=lambda th: _fake_resid(th, x),
+        seed=99,
+        fit_ctx={},
+        workers=0,
+        return_band=False,
+    )
+    r2 = U.bayesian_ci(
+        theta_hat=theta,
+        model=lambda th: _fake_predict(th, x),
+        predict_full=lambda th: _fake_predict(th, x),
+        x_all=x,
+        y_all=y,
+        residual_fn=lambda th: _fake_resid(th, x),
+        seed=99,
+        fit_ctx={},
+        workers=0,
+        return_band=False,
+    )
+    assert r1.stats == r2.stats
+
+
+def test_bayesian_band_produces_subset_when_forced(monkeypatch):
+    emcee = pytest.importorskip("emcee")
+    monkeypatch.setattr(emcee, "EnsembleSampler", _DummySamplerBand)
+
+    x = np.linspace(0, 1, 64)
+    y = np.zeros_like(x)
+    theta = np.array([0.2, 1.5, 0.1, -0.05])
+    logs: list[str] = []
+
+    def predict(th):
+        return th[0] + th[1] * x
+
+    fit_ctx = {
+        "alpha": 0.1,
+        "bayes_band_enabled": True,
+        "bayes_band_force": True,
+        "progress_cb": logs.append,
+    }
+
+    res = U.bayesian_ci(
+        theta_hat=theta,
+        model=predict,
+        predict_full=predict,
+        x_all=x,
+        y_all=y,
+        residual_fn=lambda th: _fake_resid(th, x),
+        seed=123,
+        fit_ctx=fit_ctx,
+        n_walkers=4,
+        n_burn=1,
+        n_steps=64,
+        thin=2,
+        workers=0,
+        return_band=True,
+    )
+
+    assert res.band is not None
+    xb, lo, hi = res.band
+    assert xb.shape == x.shape
+    assert lo.shape == x.shape
+    assert hi.shape == x.shape
+    assert res.diagnostics["band_source"] == "posterior_predictive_subset"
+    assert res.diagnostics["band_gated"] is False
+    assert res.diagnostics.get("band_forced") is True
+    assert res.diagnostics["band_draws_used"] <= 512
+    assert any("Bayesian band" in msg for msg in logs)
+
+
+def test_bayesian_band_gated_without_force(monkeypatch):
+    emcee = pytest.importorskip("emcee")
+    monkeypatch.setattr(emcee, "EnsembleSampler", _DummySamplerBand)
+
+    x = np.linspace(0, 1, 32)
+    y = np.zeros_like(x)
+    theta = np.array([0.2, 1.5, 0.1, -0.05])
+
+    def predict(th):
+        return th[0] + th[1] * x
+
+    fit_ctx = {
+        "bayes_band_enabled": True,
+        "bayes_diagnostics": True,
+        "bayes_diag_ess_min": 1e9,
+        "bayes_diag_rhat_max": 0.9,
+        "bayes_diag_mcse_mean": 1e-6,
+    }
+
+    res = U.bayesian_ci(
+        theta_hat=theta,
+        model=predict,
+        predict_full=predict,
+        x_all=x,
+        y_all=y,
+        residual_fn=lambda th: _fake_resid(th, x),
+        seed=321,
+        fit_ctx=fit_ctx,
+        n_walkers=4,
+        n_burn=1,
+        n_steps=64,
+        thin=2,
+        workers=0,
+        return_band=True,
+    )
+
+    assert res.band is None
+    assert res.diagnostics["band_gated"] is True
+    assert res.diagnostics.get("band_forced") is False
+    assert res.diagnostics["band_source"] is None
+    assert res.diagnostics["band_draws_used"] > 0
+
+    fit_ctx_forced = dict(fit_ctx, bayes_band_force=True)
+    res_forced = U.bayesian_ci(
+        theta_hat=theta,
+        model=predict,
+        predict_full=predict,
+        x_all=x,
+        y_all=y,
+        residual_fn=lambda th: _fake_resid(th, x),
+        seed=321,
+        fit_ctx=fit_ctx_forced,
+        n_walkers=4,
+        n_burn=1,
+        n_steps=64,
+        thin=2,
+        workers=0,
+        return_band=True,
+    )
+
+    assert res_forced.band is not None
+    assert res_forced.diagnostics["band_gated"] is False
+    assert res_forced.diagnostics.get("band_forced") is True

--- a/tests/test_smoke_gui_vs_batch_unc.py
+++ b/tests/test_smoke_gui_vs_batch_unc.py
@@ -94,6 +94,14 @@ def _fit_once_gui_style(x, y, *, config):
         "bootstrap_jitter": float(config.get("bootstrap_jitter", 0.02)) if float(config.get("bootstrap_jitter", 0.02)) <= 1.0 else float(config.get("bootstrap_jitter", 0.02))/100.0,
     }
 
+    seed_cfg = config.get("perf_seed", "")
+    try:
+        seed_val = int(seed_cfg) if str(seed_cfg) not in ("", "None") else None
+    except Exception:
+        seed_val = None
+    if not bool(config.get("perf_seed_all", False)):
+        seed_val = None
+
     unc_res = bootstrap_ci(
         theta=theta_hat,
         residual=np.asarray(residual_vec, float),
@@ -106,7 +114,7 @@ def _fit_once_gui_style(x, y, *, config):
         param_names=out.get("param_names"),
         locked_mask=out.get("locked_mask"),
         n_boot=int(config.get("bootstrap_n", 60)),
-        seed=int(config.get("bootstrap_seed", 1234)) or None,
+        seed=seed_val,
         workers=None,
         alpha=float(config.get("unc_alpha", 0.05)),
         center_residuals=bool(config.get("unc_center_resid", True)),
@@ -127,7 +135,8 @@ def test_bootstrap_gui_vs_batch_match(tmp_path):
         "unc_boot_solver": "modern_trf",
         "unc_center_resid": True,
         "bootstrap_n": 60,
-        "bootstrap_seed": 1234,
+        "perf_seed_all": True,
+        "perf_seed": 1234,
         "bootstrap_jitter": 0.02,
         "export_unc_wide": True,
         "unc_alpha": 0.05,

--- a/tests/test_unc_stats_keys_consistent.py
+++ b/tests/test_unc_stats_keys_consistent.py
@@ -1,0 +1,91 @@
+import numpy as np
+import pytest
+
+from core.uncertainty import bootstrap_ci, bayesian_ci
+
+
+def _linear_fixture(n=60, sigma=0.03, seed=0):
+    rng = np.random.default_rng(seed)
+    x = np.linspace(0.0, 1.0, n)
+    a_true, b_true = 1.5, 0.5
+    y = a_true + b_true * x + rng.normal(scale=sigma, size=n)
+
+    # LS estimate for theta_hat = [a, b]
+    X = np.column_stack([np.ones_like(x), x])
+    th_hat, *_ = np.linalg.lstsq(X, y, rcond=None)
+    th_hat = np.asarray(th_hat, float)
+
+    def model(theta):
+        theta = np.asarray(theta, float)
+        return theta[0] + theta[1] * x
+
+    r = y - model(th_hat)
+    J = np.column_stack([-np.ones_like(x), -x])  # residual Jacobian wrt [a,b]
+
+    return x, y, th_hat, r, J, model
+
+
+def _assert_param_block_has_consistent_keys(block: dict):
+    # Ensure unified dotted quantile keys and no underscored variants
+    assert {"est", "sd", "p2.5", "p97.5"} <= set(block.keys())
+    assert "p2_5" not in block
+    assert "p97_5" not in block
+
+
+def test_stats_keys_consistent_between_bootstrap_and_bayesian():
+    x, y, theta_hat, r, J, model = _linear_fixture()
+
+    # --- Bootstrap (linearized path; band off for speed) ---
+    br = bootstrap_ci(
+        theta=theta_hat,
+        residual=r,
+        jacobian=J,
+        predict_full=model,
+        x_all=x,
+        y_all=y,
+        fit_ctx={"alpha": 0.1},
+        param_names=["a", "b"],
+        n_boot=64,
+        alpha=0.1,
+        center_residuals=True,
+        return_band=False,
+        workers=None,
+    )
+    bstats = br.stats
+
+    def _fetch_block(stats_dict, label, fallback_index):
+        if label in stats_dict:
+            return stats_dict[label]
+        fallback_key = f"p{fallback_index}"
+        assert fallback_key in stats_dict
+        return stats_dict[fallback_key]
+
+    _assert_param_block_has_consistent_keys(_fetch_block(bstats, "a", 0))
+    _assert_param_block_has_consistent_keys(_fetch_block(bstats, "b", 1))
+
+    # --- Bayesian (small run; band/diagnostics off) ---
+    try:
+        import emcee  # noqa: F401
+    except Exception:
+        pytest.skip("emcee not available")
+
+    res = bayesian_ci(
+        theta_hat=theta_hat,
+        model=model,
+        predict_full=model,
+        x_all=x,
+        y_all=y,
+        residual_fn=lambda th: y - model(th),
+        fit_ctx={"alpha": 0.1, "bayes_diagnostics": False},
+        param_names=["a", "b"],
+        n_walkers=16,
+        n_burn=100,
+        n_steps=150,
+        thin=5,
+        seed=123,
+        workers=None,
+        return_band=False,
+    )
+    stats = res.stats
+    _assert_param_block_has_consistent_keys(_fetch_block(stats, "a", 0))
+    _assert_param_block_has_consistent_keys(_fetch_block(stats, "b", 1))


### PR DESCRIPTION
## Summary
- export the shared band skip constants from the uncertainty module so the GUI can reference them without hard-coded strings
- switch Bayesian credible interval statistics to use `p2.5` / `p97.5` keys like bootstrap while keeping legacy readers tolerant of either spelling
- explicitly seed the emcee sampler’s internal RNG directly so Bayesian runs remain deterministic without relying on global RNG
- add regression tests covering quantile-key consistency, Bayesian band gating/force overrides, and seeded determinism

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68d9b04c41608330a0b9d37e19ce713c