### PR TITLE
Log effective worker counts and sync bootstrap defaults

### DIFF
--- a/tests/test_batch_band_written.py
+++ b/tests/test_batch_band_written.py
@@ -28,10 +28,9 @@ def test_batch_band_written(tmp_path):
         "perf_gpu": False,
         "perf_cache_baseline": True,
         "perf_seed_all": False,
-        "perf_max_workers": 0,
+        "perf_max_workers": 1,
         "output_dir": str(tmp_path),
         "output_base": "batch",
-        "unc_workers": 0,
     }
 
     ok, total = runner.run_batch([str(p)], cfg, compute_uncertainty=True, unc_method="Asymptotic")

--- a/tests/test_batch_toggle_respected.py
+++ b/tests/test_batch_toggle_respected.py
@@ -23,10 +23,9 @@ def test_batch_toggle_respected(tmp_path):
         "auto_max":5,
         "classic":{},
         "baseline_uses_fit_range":True,
-        "perf_numba":False,"perf_gpu":False,"perf_cache_baseline":True,"perf_seed_all":False,"perf_max_workers":0,
+        "perf_numba":False,"perf_gpu":False,"perf_cache_baseline":True,"perf_seed_all":False,"perf_max_workers":1,
         "output_dir":str(tmp_path),
         "output_base":"batch",
-        "unc_workers":0,
     }
 
     # OFF: no per-file unc files, no batch uncertainty

--- a/tests/test_batch_uncertainty_exports.py
+++ b/tests/test_batch_uncertainty_exports.py
@@ -30,10 +30,9 @@ def test_batch_uncertainty_exports(tmp_path, method):
         "perf_gpu": False,
         "perf_cache_baseline": True,
         "perf_seed_all": False,
-        "perf_max_workers": 0,
+        "perf_max_workers": 1,
         "output_dir": str(tmp_path),
         "output_base": "batch",
-        "unc_workers": 0,
     }
 
     ok, total = runner.run_batch([str(p)], cfg, compute_uncertainty=True, unc_method=method)

--- a/tests/test_unc_workers_vs_seed_all.py
+++ b/tests/test_unc_workers_vs_seed_all.py
@@ -16,13 +16,9 @@ def test_unc_workers_vs_seed_all(monkeypatch):
     root = tk.Tk()
     root.withdraw()
     app = PeakFitApp(root)
-    label_text = app.unc_workers_label.cget("text")
+    assert not hasattr(app, "unc_workers_label")
     app.perf_seed_all.set(True)
     root.update_idletasks()
-    assert app.unc_workers_label.cget("text") == label_text
-    app.unc_workers_var.set(2)
-    assert app._resolve_unc_workers() == 2
-    app.unc_workers_var.set(0)
     app.perf_max_workers.set(3)
     assert app._resolve_unc_workers() == 3
     app.perf_max_workers.set(0)


### PR DESCRIPTION
## Summary
- log the auto-resolved worker count when applying performance settings and tighten Bayesian walker clamping and band toggle enablement
- ensure batch processing reuses the configured bootstrap draw count in every uncertainty path while continuing to pass the value through to the router
- clarify the performance seeding helper to document explicit seeding and rely on the auto worker resolution when reporting status

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d9f2f3ea348330b3b7f710d64c0fe6